### PR TITLE
option to serve a static folder in serveHTTP function with opts.static

### DIFF
--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -1,4 +1,6 @@
 const express = require('express')
+const fs = require('fs')
+const path = require('path')
 const landingTemplate = require('./landingTemplate')
 const getRouter = require('./getRouter')
 const opn = require('opn')
@@ -13,6 +15,13 @@ function serveHTTP(addonInterface, opts = {}) {
 		next()
 	})
 	app.use(getRouter(addonInterface))
+
+	// serve static dir
+	if (opts.static) {
+		const location = path.join(process.cwd(), opts.static)
+		if (!fs.existsSync(location)) throw `directory to serve ${location} does not exist`
+		app.use(opts.static, express.static(location))
+	}
 
 	// landing page
 	const landingHTML = landingTemplate(addonInterface.manifest)

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -19,7 +19,7 @@ function serveHTTP(addonInterface, opts = {}) {
 	// serve static dir
 	if (opts.static) {
 		const location = path.join(process.cwd(), opts.static)
-		if (!fs.existsSync(location)) throw `directory to serve ${location} does not exist`
+		if (!fs.existsSync(location)) throw new Error('directory to serve does not exist')
 		app.use(opts.static, express.static(location))
 	}
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -90,6 +90,28 @@ tape('create an addon and expose on HTTP with serveHTTP()', function(t) {
 	})
 })
 
+tape('try to serve a directory', function (t) {
+	var addon = new addonBuilder(manifest)
+		.defineCatalogHandler(() => Promise.resolve())
+		.defineStreamHandler(() => Promise.resolve())
+
+	serveHTTP(addon.getInterface(), { static: '/docs' }).then(function (h) {
+		request(h.server)
+			.get('/docs/README.md')
+			.expect(200)
+			.end((err, res) => {
+				h.server.close()
+				t.error(err, 'request error')
+				t.error(res.error, 'response error')
+				t.equal(res.ok, true, 'has response status 200')
+				t.equal(res.status, 200, 'has response status ok')
+				t.equal(res.type, 'text/markdown', 'is a valid markdown document')
+				t.end()
+			})
+
+	})
+})
+
 // Test the homepage of the addon
 tape('should return a valid html document', function (t) {
 	request(addonServer)

--- a/test/basic.js
+++ b/test/basic.js
@@ -90,6 +90,18 @@ tape('create an addon and expose on HTTP with serveHTTP()', function(t) {
 	})
 })
 
+tape('try to serve a directory that does not exist', function (t) {
+	var addon = new addonBuilder(manifest)
+		.defineCatalogHandler(() => Promise.resolve())
+		.defineStreamHandler(() => Promise.resolve())
+	try {
+		serveHTTP(addon.getInterface(), { static: '/notexist' })
+	} catch (e) {
+		t.equal(e.message, 'directory to serve does not exist')
+		t.end()
+	}
+})
+
 tape('try to serve a directory', function (t) {
 	var addon = new addonBuilder(manifest)
 		.defineCatalogHandler(() => Promise.resolve())
@@ -108,7 +120,6 @@ tape('try to serve a directory', function (t) {
 				t.equal(res.type, 'text/markdown', 'is a valid markdown document')
 				t.end()
 			})
-
 	})
 })
 


### PR DESCRIPTION
I added an option for devs to serve a static dir (with images for example), I find this very useful when I don't want to host my images on another server for each addon. 
Usage: `serveHTTP(addonInterface, { port: 4657, static: '/static' }`
Do you think that's a good thing to add and does this follow your dev practices ?