### PR TITLE
Allow URL sets

### DIFF
--- a/docs/api/responses/stream.md
+++ b/docs/api/responses/stream.md
@@ -9,6 +9,7 @@ Used as a response for [`defineStreamHandler`](../requests/defineStreamHandler.m
 * ``infoHash`` - string, info hash of a torrent file, and `fileIdx` is the index of the video file within the torrent; **if fileIdx is not specified, the largest file in the torrent will be selected**
 * ``fileIdx`` - number, the index of the video file within the torrent (from `infoHash`); **if fileIdx is not specified, the largest file in the torrent will be selected**
 * ``externalUrl`` - string, URL to the video, which should be opened in a browser (webpage), e.g. link to Netflix
+* ``urlSet`` - string array, direct URLs to identical video streams. Used for hosting the same content in different regions or at different qualities - http, https, rtmp protocols supported
 
 ### Additional properties to provide information / behaviour flags
 

--- a/docs/api/responses/stream.md
+++ b/docs/api/responses/stream.md
@@ -9,7 +9,7 @@ Used as a response for [`defineStreamHandler`](../requests/defineStreamHandler.m
 * ``infoHash`` - string, info hash of a torrent file, and `fileIdx` is the index of the video file within the torrent; **if fileIdx is not specified, the largest file in the torrent will be selected**
 * ``fileIdx`` - number, the index of the video file within the torrent (from `infoHash`); **if fileIdx is not specified, the largest file in the torrent will be selected**
 * ``externalUrl`` - string, URL to the video, which should be opened in a browser (webpage), e.g. link to Netflix
-* ``urlSet`` - string array, direct URLs to identical video streams. Used for hosting the same content in different regions or at different qualities - http, https, rtmp protocols supported
+* ``urlSet`` - string array, direct URLs to identical video streams. Used for hosting the same content in different regions or at different qualities. Urls should be in order of preference - http, https, rtmp protocols supported
 
 ### Additional properties to provide information / behaviour flags
 


### PR DESCRIPTION
Allow addons to provide sets of URLs that should function as the same content. This list should be in the order of preference, allowing the client to iterate through them until one is successful. This would allow the client to select the source with better availability, increasing user comfort.

> There is no specification for what counts as 'successful', but it should probably be when the stream is fast enough to be played in real time

This could also optionally be an update to the `url` property, treating strings as arrays with a single element for backwards compatibility.

Though this will need some work to fully implement in the client, I think it would be good to add it to the docs so that addons can start implementing support now, and add a line like this to the stream object parser

```js
url = url instanceof Array ? url[0] : url
```
