### PR TITLE
Give meaning to the order of streams

### DIFF
--- a/docs/api/requests/defineStreamHandler.md
+++ b/docs/api/requests/defineStreamHandler.md
@@ -8,7 +8,7 @@ This method handles stream requests.
 
 ### Returns:
 
-A promise resolving to an an object containing `{ streams: [] }` with an array of [Stream Objects](../responses/stream.md).
+A promise resolving to an an object containing `{ streams: [] }` with an array of [Stream Objects](../responses/stream.md). The streams should be ordered from highest to lowest quality
 
 The resolving object can also include `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options).
 


### PR DESCRIPTION
Continuation of #72 

It seems as if this relationship between streams is already mostly considered, and most stream providers already order their content in this way for visibility.

It would be good to make the ordering standard so that it can be used by clients.

> Looking at it *again*, the current system seems to treat each stream in that list as if it is standalone. What is the relationship between an addon's meta and stream list for an individual id meant to be? Based on the structure, it seems as if it should be reasonable to use the meta's name for the listing, but it would be good to hear your thoughts on this. Maybe #72 is actually needed?