### PR TITLE
clarify exclusiveness of video.streams

### DIFF
--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -57,7 +57,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``thumbnail`` - _optional_ - URL to png of the video thumbnail, in the video's aspect ratio, max file size 5kb
 
-``streams`` - _optional_ - In case you can return links to streams while forming meta response, **you can pass and array of [``Stream Objects``](./stream.md)** to point the video to a HTTP URL, BitTorrent, YouTube or any other stremio-supported transport protocol.
+``streams`` - _optional_ - In case you can return links to streams while forming meta response, **you can pass and array of [``Stream Objects``](./stream.md)** to point the video to a HTTP URL, BitTorrent, YouTube or any other stremio-supported transport protocol; note that this is exclsuive: passing `video.streams` means that **Stremio will not** request any streams from other add-ons for that video; if you return streams that way, it is still recommended to implement the `streams` resource
 
 ``available`` - _optional_ - set to ``true`` to explicitly state that this video is available for streaming, from your add-on; no need to use this if you've passed ``stream``
 


### PR DESCRIPTION
providing `video.streams` for the video implies exclusivity 

To supply streams non-exclusively, use the separate streams resource 

The reason for this decision is that there’s no other method to reliably and cleanly implement exclusivity, but it’s needed in some cases (eg the YouTube addon) 

Furthermore, exclusivity is a great thing to have for monolithic VOD addons (that provide meta+streams), cause other addons cant “mess” with their UX 