### PR TITLE
Fix Extra Parameters

### DIFF
--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -19,6 +19,9 @@ function getRouter({ manifest , get }) {
 	// Handle all resources
 	router.get('/:resource/:type/:id/:extra?.json', function(req, res, next) {
 		const { resource, type, id } = req.params
+		// we get `extra` from `req.url` because `req.params.extra` decodes the characters
+		// and breaks dividing querystring parameters with `&`, in case `&` is one of the
+		// encoded characters of a parameter value
 		const extra = req.params.extra ? qs.parse(req.url.split('/').pop().slice(0, -5)) : {}
 		get(resource, type, id, extra)
 			.then(resp => {

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -19,7 +19,7 @@ function getRouter({ manifest , get }) {
 	// Handle all resources
 	router.get('/:resource/:type/:id/:extra?.json', function(req, res, next) {
 		const { resource, type, id } = req.params
-		const extra = req.params.extra ? qs.parse(req.params.extra) : {}
+		const extra = req.params.extra ? qs.parse(req.url.split('/').pop().slice(0, -5)) : {}
 		get(resource, type, id, extra)
 			.then(resp => {
 				if (resp.cacheMaxAge) res.setHeader('Cache-Control', 'max-age='+resp.cacheMaxAge)


### PR DESCRIPTION
The issues:

`extra` uses the querystring pattern, because we set `extra` as a router parameter (`/:resource/:type/:id/:extra?.json`), the router automatically uses `decodeURIComponent()` on it's value. This causes a problem if the parameter itself includes an encoded version of `&`, which later when we use `querystring.parse()` on the value is seen as a parameter divider, and thus breaks it's original value.


The solution:

Using `req.url` instead of `req.params.extra`, because `req.url` is still correctly encoded and causes no issues when using `querystring.parse()` 