### PR TITLE
Cache header changes

### DIFF
--- a/docs/api/requests/defineCatalogHandler.md
+++ b/docs/api/requests/defineCatalogHandler.md
@@ -11,7 +11,13 @@ This method handles catalog requests, including search.
 
 A promise that resolves to an object containing `{ metas: [] }` with an array of [Meta Preview Object](../responses/meta.md#meta-preview-object)
 
-The resolving object can also include `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options).
+The resolving object can also include the following cache related properties:
+
+- `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options)
+
+- `{ staleRevalidate: int }` (in seconds) which sets the `Cache-Control` header to `stale-while-revalidate=$staleRevalidate`
+
+- `{ staleError: int }` (in seconds) which sets the `Cache-Control` header to `stale-if-error=$staleError`
 
 
 ## Request Parameters

--- a/docs/api/requests/defineMetaHandler.md
+++ b/docs/api/requests/defineMetaHandler.md
@@ -10,7 +10,13 @@ This method handles metadata requests. (title, year, poster, background, etc.)
 
 A promise resolving to an object containing `{ meta: {} }` with a [Meta Object](../responses/meta.md)
 
-The resolving object can also include `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options).
+The resolving object can also include the following cache related properties:
+
+- `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options)
+
+- `{ staleRevalidate: int }` (in seconds) which sets the `Cache-Control` header to `stale-while-revalidate=$staleRevalidate`
+
+- `{ staleError: int }` (in seconds) which sets the `Cache-Control` header to `stale-if-error=$staleError`
 
 
 ## Request Parameters

--- a/docs/api/requests/defineStreamHandler.md
+++ b/docs/api/requests/defineStreamHandler.md
@@ -10,7 +10,13 @@ This method handles stream requests.
 
 A promise resolving to an an object containing `{ streams: [] }` with an array of [Stream Objects](../responses/stream.md). The streams should be ordered from highest to lowest quality
 
-The resolving object can also include `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options).
+The resolving object can also include the following cache related properties:
+
+- `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options)
+
+- `{ staleRevalidate: int }` (in seconds) which sets the `Cache-Control` header to `stale-while-revalidate=$staleRevalidate`
+
+- `{ staleError: int }` (in seconds) which sets the `Cache-Control` header to `stale-if-error=$staleError`
 
 
 ## Request Parameters

--- a/docs/api/requests/defineSubtitlesHandler.md
+++ b/docs/api/requests/defineSubtitlesHandler.md
@@ -10,7 +10,13 @@ This method handles subtitle requests.
 
 A promise resolving to an object containing `{ subtitles: [] }` with an array of [Subtitle Objects](../responses/subtitles.md).
 
-The resolving object can also include `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options).
+The resolving object can also include the following cache related properties:
+
+- `{ cacheMaxAge: int }` (in seconds) which sets the `Cache-Control` header to `max-age=$cacheMaxAge` and overwrites the global cache time set in `serveHTTP` [options](../../README.md#servehttpaddoninterface-options)
+
+- `{ staleRevalidate: int }` (in seconds) which sets the `Cache-Control` header to `stale-while-revalidate=$staleRevalidate`
+
+- `{ staleError: int }` (in seconds) which sets the `Cache-Control` header to `stale-if-error=$staleError`
 
 
 ## Request Parameters

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -32,17 +32,16 @@ function getRouter({ manifest , get }) {
 					staleError: 'stale-if-error'
 				}
 
-				let cacheControl = ''
-
-				for (let prop in cacheHeaders)
-					if (resp[prop]) {
-						if (resp[prop] > 365 * 24 * 60 * 60)
-							console.warn(prop + ' set to more then 1 year, be advised that cache times are in seconds, not milliseconds.')
-						cacheControl += (cacheControl ? ', ' : '') + cacheHeaders[prop] + '=' + resp[prop]
-					}
+				const cacheControl = Object.keys(cacheHeaders).map(prop => {
+					const value = resp[prop]
+					if (!value) return false
+					if (value > 365 * 24 * 60 * 60)
+						console.warn(`${prop} set to more then 1 year, be advised that cache times are in seconds, not milliseconds.`)
+					return cacheHeaders[prop] + '=' + value
+				}).filter(val => !!val).join(', ')
 
 				if (cacheControl)
-					res.setHeader('Cache-Control', cacheControl + ', public')
+					res.setHeader('Cache-Control', `${cacheControl}, public`)
 
 				res.setHeader('Content-Type', 'application/json; charset=utf-8')
 

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -25,7 +25,11 @@ function getRouter({ manifest , get }) {
 		const extra = req.params.extra ? qs.parse(req.url.split('/').pop().slice(0, -5)) : {}
 		get(resource, type, id, extra)
 			.then(resp => {
-				if (resp.cacheMaxAge) res.setHeader('Cache-Control', 'max-age='+resp.cacheMaxAge+', public')
+				if (resp.cacheMaxAge) {
+					if (resp.cacheMaxAge > 365 * 24 * 60 * 60)
+						console.warn('cacheMaxAge set to more then 1 year, be advised that cache times are in seconds, not milliseconds.')
+					res.setHeader('Cache-Control', 'max-age='+resp.cacheMaxAge+', public')
+				}
 				res.setHeader('Content-Type', 'application/json; charset=utf-8')
 				res.end(JSON.stringify(resp))
 			})

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -9,7 +9,12 @@ function serveHTTP(addonInterface, opts = {}) {
 	if (addonInterface.constructor.name !== 'AddonInterface') {
 		throw new Error('first argument must be an instance of AddonInterface')
 	}
+
 	const cacheMaxAge = opts.cacheMaxAge || opts.cache
+
+	if (cacheMaxAge > 365 * 24 * 60 * 60)
+		console.warn('cacheMaxAge set to more then 1 year, be advised that cache times are in seconds, not milliseconds.')
+
 	const app = express()
 	app.use((_, res, next) => {
 		if (cacheMaxAge && !res.getHeader('Cache-Control'))


### PR DESCRIPTION
Adds `staleRevalidate` and `staleError` as cache properties to responses and documents them.

This PR also adds a warning to all cache headers (currently `cacheMaxAge`, `staleRevalidate` and `staleError`) if they are set to a higher value then 1 year. The warning mentions that cache times are in seconds, not milliseconds.