### PR TITLE
Rename "add-on" to "addon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Stremio Add-on SDK 🧙
+# Stremio Addon SDK 🧙
 
 ![Stremio](https://www.stremio.com/website/stremio-purple-small.png)
 
-The **🧙  Stremio Add-on SDK 🧙** was developed by the Stremio Team as a way of vastly simplifying Node.js add-on creation for
+The **🧙  Stremio Addon SDK 🧙** was developed by the Stremio Team as a way of vastly simplifying Node.js addon creation for
 our streaming platform.
 
 Stremio currently supports Windows, macOS, Linux, Android and iOS.
@@ -10,7 +10,7 @@ Stremio currently supports Windows, macOS, Linux, Android and iOS.
 
 ## Quick Example
 
-This arbitrary example creates an add-on that provides a stream for Big Buck Bunny and outputs a HTTP address where you can access it.
+This arbitrary example creates an addon that provides a stream for Big Buck Bunny and outputs a HTTP address where you can access it.
 
 ```javascript
 const { addonBuilder, serveHTTP, publishToCentral }  = require('stremio-addon-sdk')
@@ -21,8 +21,8 @@ const builder = new addonBuilder({
 
     name: 'simple example',
 
-    // Properties that determine when Stremio picks this add-on
-    // this means your add-on will be used for streams of the type movie
+    // Properties that determine when Stremio picks this addon
+    // this means your addon will be used for streams of the type movie
     catalogs: [],
     resources: ['stream'],
     types: ['movie'],
@@ -42,7 +42,7 @@ builder.defineStreamHandler(function(args) {
 })
 
 serveHTTP(builder.getInterface(), { port: 7000 })
-//publishToCentral("https://your-domain/manifest.json") // <- invoke this if you want to publish your add-on and it's accessible publically on "your-domain"
+//publishToCentral("https://your-domain/manifest.json") // <- invoke this if you want to publish your addon and it's accessible publically on "your-domain"
 ```
 
 Save this as `addon.js` and run:
@@ -52,14 +52,14 @@ npm install stremio-addon-sdk
 node ./addon.js
 ```
 
-It will output a URL that you can use to [install the add-on in Stremio](./docs/testing.md#how-to-install-add-on-in-stremio)
+It will output a URL that you can use to [install the addon in Stremio](./docs/testing.md#how-to-install-add-on-in-stremio)
 
-**Please note:** add-on URLs in Stremio must be loaded with HTTPS (except `127.0.0.1`) and must support CORS! CORS support is handled automatically by the SDK, but if you're trying to load your add-on remotely (not from `127.0.0.1`), you need to support HTTPS.
+**Please note:** addon URLs in Stremio must be loaded with HTTPS (except `127.0.0.1`) and must support CORS! CORS support is handled automatically by the SDK, but if you're trying to load your addon remotely (not from `127.0.0.1`), you need to support HTTPS.
 
 
-## Getting started with a new add-on
+## Getting started with a new addon
 
-In order to scaffold a new Stremio add-on, we've made a tool called `addon-bootstrap`.
+In order to scaffold a new Stremio addon, we've made a tool called `addon-bootstrap`.
 
 You can use it in the following way:
 
@@ -68,7 +68,7 @@ npm install -g stremio-addon-sdk # use sudo if on Linux
 addon-bootstrap hello-world
 ```
 
-You'll be asked about what [resources and types](./docs/api/README.md) you want to support, after which the add-on will be created in the `hello-world` directory, and you'll be able to run it:
+You'll be asked about what [resources and types](./docs/api/README.md) you want to support, after which the addon will be created in the `hello-world` directory, and you'll be able to run it:
 
 ```bash
 cd hello-world
@@ -76,33 +76,33 @@ npm install
 npm start -- --launch
 ```
 
-If you wish to install the add-on in the Desktop version of Stremio (which you can [download here](https://www.stremio.com/downloads)), you should use `npm start -- --install`
+If you wish to install the addon in the Desktop version of Stremio (which you can [download here](https://www.stremio.com/downloads)), you should use `npm start -- --install`
 
 ## Documentation
 
 All our documentation is [right here on GitHub](./docs). Take a look at our [examples list](./docs/examples.md) for some high-level
 information, or dive straight into our [SDK documentation](./docs/README.md) for our code reference docs.
 
-We also have an [example add-on](https://github.com/Stremio/addon-helloworld) that you can use as a guide to help you build your own add-on.
+We also have an [example addon](https://github.com/Stremio/addon-helloworld) that you can use as a guide to help you build your own addon.
 
 We've made two step by step guides: one for this SDK, and one for any programming language, [which you can read here](https://stremio.github.io/stremio-addon-guide).
 
-If you don't wish to use Node.js (and therefore not use this SDK either), you can create add-ons in any programming
-language, see the [add-on protocol specification](./docs/protocol.md) for more information.
+If you don't wish to use Node.js (and therefore not use this SDK either), you can create addons in any programming
+language, see the [addon protocol specification](./docs/protocol.md) for more information.
 
-It is also possible to create an add-on without any programming language, see our [static add-on example](https://github.com/Stremio/stremio-static-addon-example) based
+It is also possible to create an addon without any programming language, see our [static addon example](https://github.com/Stremio/stremio-static-addon-example) based
 on the protocol specification.
 
 SDK Features Include:
 
-- Publishing an add-on through HTTP(s)
-- Publishing an add-on through IPFS
-- Publishing your add-on link to the [public Add-on collection](https://api.strem.io/addonscollection.json) with [publishToCentral](./docs/README.md#publishtocentralurl)
-- Creating a homepage for your add-on that includes an "Install Add-on" button
+- Publishing an addon through HTTP(s)
+- Publishing an addon through IPFS
+- Publishing your addon link to the [public Addon collection](https://api.strem.io/addonscollection.json) with [publishToCentral](./docs/README.md#publishtocentralurl)
+- Creating a homepage for your addon that includes an "Install Addon" button
 
 ## Testing
 
-For developers looking for a quick way to test their new add-ons, you can either:
+For developers looking for a quick way to test their new addons, you can either:
 
 - [Test with Stremio](./docs/testing.md#testing-in-stremio-app)
 - [Test with our Web Version](./docs/testing.md#testing-in-stremio-web-version)
@@ -110,16 +110,16 @@ For developers looking for a quick way to test their new add-ons, you can either
 
 ## Deploying
 
-In order for your add-on to be used by others, it needs to be deployed online.
+In order for your addon to be used by others, it needs to be deployed online.
 
 You can check our [list of recommended hosting providers for Node.js](./docs/deploying/README.md) or alternatively host it locally with [localtunnel](https://github.com/localtunnel/localtunnel).
 
-After you've deployed publically, in order to get your add-on to show in Stremio (through the [public Add-on collection](https://api.strem.io/addonscollection.json)), you need to use [publishToCentral](./docs/README.md#publishtocentralurl) or publish [manually through the UI](https://stremio.github.io/stremio-publish-addon/index.html).
+After you've deployed publically, in order to get your addon to show in Stremio (through the [public Addon collection](https://api.strem.io/addonscollection.json)), you need to use [publishToCentral](./docs/README.md#publishtocentralurl) or publish [manually through the UI](https://stremio.github.io/stremio-publish-addon/index.html).
 
 
 ### IPFS deployment
 
-You can optionally deploy your add-on to IPFS, which is very similar to a P2P Torrent network. It is recommended to publish to IPFS to ensure addon longevity and your privacy.
+You can optionally deploy your addon to IPFS, which is very similar to a P2P Torrent network. It is recommended to publish to IPFS to ensure addon longevity and your privacy.
 
 In order to use the IPFS features of `stremio-addon-sdk`, you will need to also:
 
@@ -147,7 +147,7 @@ Environment variables:
 
 Publishing to IPFS requires a Supernode, if one is not given, then it will presume that a Supernode is running locally and attempt to connect to it.
 
-`./cli/publish.js <addonUrl>` - publish the add-on at the provided transport URL
+`./cli/publish.js <addonUrl>` - publish the addon at the provided transport URL
 
 Options:
 
@@ -159,17 +159,17 @@ Options:
 
 ## Examples & tutorials
 
-Check out our ever growing list of [examples and demo add-ons](./docs/examples.md). This list also includes examples & tutorials on how to develop Stremio addons in PHP, Python, Ruby, C#, Java and Go. It also includes a list of video tutorials.
+Check out our ever growing list of [examples and demo addons](./docs/examples.md). This list also includes examples & tutorials on how to develop Stremio addons in PHP, Python, Ruby, C#, Java and Go. It also includes a list of video tutorials.
 
 
 ## Advanced Usage
 
-Read our [guide for advanced usage](./docs/advanced.md) to understand the many ways that add-ons can be used.
+Read our [guide for advanced usage](./docs/advanced.md) to understand the many ways that addons can be used.
 
 
 ## Reporting Issues
 
-If you have any issues regarding the Stremio Add-on SDK, please feel free to [report them here](https://github.com/Stremio/stremio-addon-sdk/issues).
+If you have any issues regarding the Stremio Addon SDK, please feel free to [report them here](https://github.com/Stremio/stremio-addon-sdk/issues).
 
 
 ## Migration from v0.x
@@ -181,13 +181,13 @@ To migrate from v0.x, you need to:
 - all handlers have to return a `Promise` (rather than take a `cb`)
 
 
-## Use Cases Outside Add-on SDK
+## Use Cases Outside Addon SDK
 
-The use of this SDK is not mandatory for creating Stremio Add-ons. You can use any programming language that supports
-creating a HTTP server to make Stremio Add-ons. Refer to our [protocol specification](./docs/protocol.md) for details and examples.
+The use of this SDK is not mandatory for creating Stremio Addons. You can use any programming language that supports
+creating a HTTP server to make Stremio Addons. Refer to our [protocol specification](./docs/protocol.md) for details and examples.
 
-One useful scenario of not using the SDK is when you need user specific data for you add-on (for example, an API
-Autherntication Token), you can see an example of passing user specific data in the Add-on URL [here](./docs/advanced.md#using-user-data-in-add-ons).
+One useful scenario of not using the SDK is when you need user specific data for you addon (for example, an API
+Autherntication Token), you can see an example of passing user specific data in the Addon URL [here](./docs/advanced.md#using-user-data-in-add-ons).
 This example uses Node.js and Express to get user specific data.
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 # Getting Started
 
-A NodeJS SDK for making and publishing Stremio add-ons
+A NodeJS SDK for making and publishing Stremio addons
 
 ## Example
 
-**This arbitrary example creates an add-on that provides a stream for Big Buck Bunny and outputs a HTTP address where you can access it**
+**This arbitrary example creates an addon that provides a stream for Big Buck Bunny and outputs a HTTP address where you can access it**
 
 ```javascript
 #!/usr/bin/env node
@@ -17,8 +17,8 @@ const builder = new addonBuilder({
 
     name: 'simple example',
 
-    // Properties that determine when Stremio picks this add-on
-    // this means your add-on will be used for streams of the type movie
+    // Properties that determine when Stremio picks this addon
+    // this means your addon will be used for streams of the type movie
     resources: ['stream'],
     types: ['movie'],
     idPrefixes: ['tt']
@@ -39,7 +39,7 @@ builder.defineStreamHandler(function(args) {
 
 serveHTTP(builder.getInterface(), { port: 7000 })
 
-// If you want this add-on to appear in the addon catalogs, call .publishToCentral() with the publically available URL to your manifest
+// If you want this addon to appear in the addon catalogs, call .publishToCentral() with the publically available URL to your manifest
 //publishToCentral('https://my-addon.com/manifest.json')
 
 ```
@@ -51,7 +51,7 @@ npm install stremio-addon-sdk
 node ./addon.js
 ```
 
-It will output a URL that you can use to [install the add-on in Stremio](./docs/testing.md#how-to-install-add-on-in-stremio)
+It will output a URL that you can use to [install the addon in Stremio](./docs/testing.md#how-to-install-add-on-in-stremio)
 
 ## Documentation
 
@@ -64,14 +64,14 @@ Imports everything the SDK provides:
 * `addonBuilder`, which you'll need to define the addon
 * `serveHTTP`, which you will need to serve a HTTP server for this addon
 * `getRouter`, converts an `addonInterface` to an express router
-* `publishToCentral`: publishes an add-on URL to the public add-on catalog
+* `publishToCentral`: publishes an addon URL to the public addon catalog
 
 
 #### `const builder = new addonBuilder(manifest)`
 
-Creates an  add-on builder obbject with a given manifest. This will throw if the manifest is not valid.
+Creates an  addon builder obbject with a given manifest. This will throw if the manifest is not valid.
 
-The manifest will determine the basic information of your add-on (name, description, images), but most importantly, it will determine **when and how** your add-on will be invoked by Stremio.
+The manifest will determine the basic information of your addon (name, description, images), but most importantly, it will determine **when and how** your addon will be invoked by Stremio.
 
 [Manifest Object Definition](./api/responses/manifest.md)
 
@@ -106,9 +106,9 @@ Handles subtitle requests.
 
 #### `builder.defineResourceHandler('addon_catalog', function handler(args) { })`
 
-Handles add-on catalog requests, this can be used by an add-on to just send a list of other add-on manifests.
+Handles addon catalog requests, this can be used by an addon to just send a list of other addon manifests.
 
-[Add-on Catalog Request Parameters and Example](./api/requests/defineResourceHandler.md)
+[Addon Catalog Request Parameters and Example](./api/requests/defineResourceHandler.md)
 
 **The JSON format of the response to these resources is described [here](./api/responses).**
 
@@ -127,7 +127,7 @@ Turns the `addonInterface` into an express router, that serves the addon accordi
 
 This method expects a string with the url to your `manifest.json` file.
 
-Publish your add-on to the central server. After using this method your add-on will be available in the Community Add-ons list in Stremio for users to install and use. Your add-on needs to be publicly available with a URL in order for this to happen, as local add-ons that are not publicly available cannot be used by other Stremio users.
+Publish your addon to the central server. After using this method your addon will be available in the Community Addons list in Stremio for users to install and use. Your addon needs to be publicly available with a URL in order for this to happen, as local addons that are not publicly available cannot be used by other Stremio users.
 
 
 #### `serveHTTP(addonInterface, options)`
@@ -139,8 +139,8 @@ Starts the addon server. `options` is an object that contains:
 
 This method is also special in that it will react to certain process arguments, such as:
 
-* `--launch`: launches Stremio in the web browser, and automatically installs/upgrades the add-on
-* `--install`: installs the add-on in the desktop version of Stremio
+* `--launch`: launches Stremio in the web browser, and automatically installs/upgrades the addon
+* `--install`: installs the addon in the desktop version of Stremio
 
 
 #### `addonInterface`

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -5,15 +5,15 @@
 - [Adding Stream Results to Cinemeta Items](#adding-stream-results-to-cinemeta-items)
 - [Getting Metadata from Cinemeta](#getting-metadata-from-cinemeta)
 - [Resolving Movie / Series names to IMDB ID](#resolving-movie--series-names-to-imdb-id)
-- [Using User Data in Add-ons](#using-user-data-in-add-ons)
-- [Using Deep Links in Add-ons](#using-deep-links-in-add-ons)
-- [Proxying Other Add-ons](#proxying-other-add-ons)
-- [Crawler (Scraping) Add-ons](#crawler--scraping-add-ons)
+- [Using User Data in Addons](#using-user-data-in-add-ons)
+- [Using Deep Links in Addons](#using-deep-links-in-add-ons)
+- [Proxying Other Addons](#proxying-other-add-ons)
+- [Crawler (Scraping) Addons](#crawler--scraping-add-ons)
 
 
 ## Understanding Catalogs
 
-The `catalog` resource in Stremio add-ons can be used to:
+The `catalog` resource in Stremio addons can be used to:
 - show one or more catalogs in the Board and Discover pages, these responses can also be filtered and paginated
 - show search results from catalogs
 
@@ -245,7 +245,7 @@ builder.defineCatalogHandler(function(args) {
 
 ## Understanding Cinemeta
 
-Cinemeta is the primary add-on that Stremio uses to show Movie, Series and Anime items. Other add-ons can choose to create their own catalogs of items or respond with streams to the Cinemeta items.
+Cinemeta is the primary addon that Stremio uses to show Movie, Series and Anime items. Other addons can choose to create their own catalogs of items or respond with streams to the Cinemeta items.
 
 Cinemeta uses IMDB IDs for their metadata, to understand it's pattern:
 - `tt0111161` is the meta ID (and video ID) of a movie
@@ -254,7 +254,7 @@ Cinemeta uses IMDB IDs for their metadata, to understand it's pattern:
 
 ## Adding Stream Results to Cinemeta Items
 
-To add only stream results to Cinemeta items, you will first need to state that your add-ons id prefix is `tt` (as for IMDB IDs).
+To add only stream results to Cinemeta items, you will first need to state that your addons id prefix is `tt` (as for IMDB IDs).
 
 Add these to your [manifest](./api/responses/manifest.md):
 - `resources: ["stream"]`
@@ -286,7 +286,7 @@ builder.defineStreamHandler(function(args) {
 
 There might be cases where you would need metadata based on IMDB ID. To do this, you will need both IMDB ID and the type of the item (either `movie` or `series`).
 
-Because Cinemeta is also an add-on, you can request the metadata from it.
+Because Cinemeta is also an addon, you can request the metadata from it.
 
 Here is an example using `needle` to do a HTTP request to Cinemeta for metadata:
 
@@ -329,11 +329,11 @@ nameToImdb({ name: "south park" }, function(err, res, inf) {
 Also setting the `type` and `year` in the request helps on ensuring that the IMDB ID that is returned is correct.
 
 
-## Using User Data in Add-ons
+## Using User Data in Addons
 
-This example does not use the Stremio Add-on SDK, it uses Node.js and Express to serve replies.
+This example does not use the Stremio Addon SDK, it uses Node.js and Express to serve replies.
 
-User data is passed in the Add-on Repository URL, so instead of users installing add-ons from the normal manifest url (for example: `https://www.mydomain.com/manifest.json`), users will also need to add the data they want to pass to the add-on in the URL (for example: `https://www.mydomain.com/c9y2kz0c26c3w4csaqne71eu4jqko7e1/manifest.json`, where `c9y2kz0c26c3w4csaqne71eu4jqko7e1` could be their API Authentication Token)
+User data is passed in the Addon Repository URL, so instead of users installing addons from the normal manifest url (for example: `https://www.mydomain.com/manifest.json`), users will also need to add the data they want to pass to the addon in the URL (for example: `https://www.mydomain.com/c9y2kz0c26c3w4csaqne71eu4jqko7e1/manifest.json`, where `c9y2kz0c26c3w4csaqne71eu4jqko7e1` could be their API Authentication Token)
 
 Simplistic Example:
 
@@ -344,7 +344,7 @@ const addon = express()
 addon.get('/:someParameter/manifest.json', function (req, res) {
   res.send({
     id: 'org.parameterized.'+req.params.someParameter,
-    name: 'add-on for '+req.params.someParameter,
+    name: 'addon for '+req.params.someParameter,
     resources: ['stream'],
     types: ['series'],
   })
@@ -360,19 +360,19 @@ addon.listen(7000, function() {
 })
 ```
 
-This is not a working example, it simply shows how data can be inserted by users in the Add-on Repository URL so add-ons can then make use of it.
+This is not a working example, it simply shows how data can be inserted by users in the Addon Repository URL so addons can then make use of it.
 
-For working examples, you can check these add-ons:
+For working examples, you can check these addons:
 - [IMDB Lists](https://github.com/jaruba/stremio-imdb-list)
 - [IMDB Watchlist](https://github.com/jaruba/stremio-imdb-watchlist)
-- [Jackett Add-on for Stremio](https://github.com/BoredLama/stremio-jackett-addon) (community built)
+- [Jackett Addon for Stremio](https://github.com/BoredLama/stremio-jackett-addon) (community built)
 
-Another use case for passing user data through the Add-on Repository URL is creating proxy add-ons. This case presumes that the id of a different add-on is sent in the Add-on Repository URL, then the proxy add-on connects to the add-on of which the id it got, requests streams, passes the stream url to some API (for example Real Debrid, Premiumize, etc) to get a different streaming url that it then responds with for Stremio.
+Another use case for passing user data through the Addon Repository URL is creating proxy addons. This case presumes that the id of a different addon is sent in the Addon Repository URL, then the proxy addon connects to the addon of which the id it got, requests streams, passes the stream url to some API (for example Real Debrid, Premiumize, etc) to get a different streaming url that it then responds with for Stremio.
 
 
-## Using Deep Links in Add-ons
+## Using Deep Links in Addons
 
-Stremio supports [deep links](./deep-links.md), such links can also be used in add-ons to link internally to Stremio.
+Stremio supports [deep links](./deep-links.md), such links can also be used in addons to link internally to Stremio.
 
 First, set the `stream` resource in your [manifest](./api/responses/manifest.md):
 - `resources: ["stream"]`
@@ -397,20 +397,20 @@ builder.defineStreamHandler(function(args) {
 ```
 
 
-## Proxying Other Add-ons
+## Proxying Other Addons
 
-Stremio add-ons use a HTTP server to handle requests and responses, this means that other add-ons can also request their responses.
+Stremio addons use a HTTP server to handle requests and responses, this means that other addons can also request their responses.
 
-This can be useful for many reasons, a guide on how this can be done is included in the readme of the [IMDB Watchlist](https://github.com/jaruba/stremio-imdb-watchlist) Add-on which proxies the [IMDB Lists](https://github.com/jaruba/stremio-imdb-list) add-on to get the IMDB List for a particular IMDB user.
+This can be useful for many reasons, a guide on how this can be done is included in the readme of the [IMDB Watchlist](https://github.com/jaruba/stremio-imdb-watchlist) Addon which proxies the [IMDB Lists](https://github.com/jaruba/stremio-imdb-list) addon to get the IMDB List for a particular IMDB user.
 
 IMDB Watchlist only proxies the catalog from IMDB Lists, to proxy other resources you can use the same pattern as IMDB Watchlist does, and check the endpoints and patterns for other resources on the [Protocol Documentation](./protocol.md) page.
 
 
 
-## Crawler / Scraping Add-ons
+## Crawler / Scraping Addons
 
 Scraping HTML pages presumes downloading the HTML source of a web page in order to get specific data from it.
 
-A guide showing a simplistic version of doing this is in the readme of the [IMDB Watchlist Add-on](https://github.com/jaruba/stremio-imdb-watchlist). The add-on uses [needle](https://www.npmjs.com/package/needle) to request the HTML source and [cheerio](https://www.npmjs.com/package/cheerio) to start a jQuery instance in order to simplify getting the desired information.
+A guide showing a simplistic version of doing this is in the readme of the [IMDB Watchlist Addon](https://github.com/jaruba/stremio-imdb-watchlist). The addon uses [needle](https://www.npmjs.com/package/needle) to request the HTML source and [cheerio](https://www.npmjs.com/package/cheerio) to start a jQuery instance in order to simplify getting the desired information.
 
 Cheerio is not the only module that can help with crawling / scraping though, other modules that can aid in this: [jsdom](https://www.npmjs.com/package/jsdom), [xpath](https://www.npmjs.com/package/xpath), etc

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,16 +1,16 @@
 # Resources
 
-In order for Stremio to display add-on data, the add-on must first supply the resource for it. There are different types of resources, the only mandatory resource is the `manifest`, add-ons can choose to supply either one or more of the other available resources.
+In order for Stremio to display addon data, the addon must first supply the resource for it. There are different types of resources, the only mandatory resource is the `manifest`, addons can choose to supply either one or more of the other available resources.
 
 
 | **Resource**  | **Handler** | **Response** | **Description** |
 | ------------- | ------------- | ------------- | ------------- |
-| **manifest** | - | [manifest](./responses/manifest.md) | The add-on description and capabilities. |
+| **manifest** | - | [manifest](./responses/manifest.md) | The addon description and capabilities. |
 | **catalog** | [defineCatalogHandler](./requests/defineCatalogHandler.md) | [meta](./responses/meta.md) | Summarized collection of meta items. Catalogs are displayed on the Stremio's Board, Discover and Search. |
 | **metadata** | [defineMetaHandler](./requests/defineMetaHandler.md) | [meta](./responses/meta.md) | Detailed description of meta item. This description is displayed when the user selects an item form the catalog. |
 | **streams** | [defineStreamHandler](./requests/defineStreamHandler.md) | [stream](./responses/stream.md) | Tells Stremio how to obtain the media content. It may be torrent info hash, HTTP URL, etc |
 | **subtitles** | [defineSubtitlesHandler](./requests/defineSubtitlesHandler.md) | [subtitles](./responses/subtitles.md) | Subtitles resource for the chosen media. |
-| **addon_catalog** | [defineResourceHandler](./requests/defineResourceHandler.md) | [addon_catalog](./responses/addon_catalog.md) | A catalog (list) of other add-on manifests. |
+| **addon_catalog** | [defineResourceHandler](./requests/defineResourceHandler.md) | [addon_catalog](./responses/addon_catalog.md) | A catalog (list) of other addon manifests. |
 
 
 The structure of those resources in Stremio is as follows:
@@ -23,19 +23,19 @@ The structure of those resources in Stremio is as follows:
         +---+---+-- Subtitles
 ```
 
-When the user opens the Discover/Board section, catalogs from all installed add-ons are loaded. Catalog responses include [meta preview objects](./responses/meta.md#meta-preview-object), which are just stripped down versions of the full meta object.
+When the user opens the Discover/Board section, catalogs from all installed addons are loaded. Catalog responses include [meta preview objects](./responses/meta.md#meta-preview-object), which are just stripped down versions of the full meta object.
 
-Once a user clicks on a specific item, the Detail page is opened, and the full meta object is loaded by requesting all relevant (see [filtering](#filtering)) add-ons.
+Once a user clicks on a specific item, the Detail page is opened, and the full meta object is loaded by requesting all relevant (see [filtering](#filtering)) addons.
 
-Then, the user will pick a video (e.g. episode) from that meta object, which will trigger loading streams from all relevant add-ons. If the meta item has only one video object (as is the case with movies), streams will be requested as soon as the Detail page is opened.
+Then, the user will pick a video (e.g. episode) from that meta object, which will trigger loading streams from all relevant addons. If the meta item has only one video object (as is the case with movies), streams will be requested as soon as the Detail page is opened.
 
 
 ## Filtering
 
-We determine whether an add-on is relevant by comparing the request against it's manifest.
+We determine whether an addon is relevant by comparing the request against it's manifest.
 
-For catalogs, we usually request all catalogs from all add-ons, that are compatible with the `extra` properties that we're looking for. For example, to load the Board, we'd load all catalogs that have no `extra` properties that are required. But, if we're loading Search, we'd load all catalogs that have `search` as a supported property in their `extra` definition.
+For catalogs, we usually request all catalogs from all addons, that are compatible with the `extra` properties that we're looking for. For example, to load the Board, we'd load all catalogs that have no `extra` properties that are required. But, if we're loading Search, we'd load all catalogs that have `search` as a supported property in their `extra` definition.
 
-For other requests (meta, stream, subtitles), we apply the `types` and the optional `idPrefixes` filters (which can also be defined per-resource). For example, for `/meta/movie/tt1254207`, we'd try to load meta from all add-ons that have `"movie"` in `manifest.types` (or have `{ name: "meta", types: ["movie'] }` in `manifest.resources`). If `manifest.idPrefixes` is defined, `["tt"]` will match this request, but something different (e.g. `["yt_id:"]`) won't. This helps you ensure your add-on does not get irrelevant requests.
+For other requests (meta, stream, subtitles), we apply the `types` and the optional `idPrefixes` filters (which can also be defined per-resource). For example, for `/meta/movie/tt1254207`, we'd try to load meta from all addons that have `"movie"` in `manifest.types` (or have `{ name: "meta", types: ["movie'] }` in `manifest.resources`). If `manifest.idPrefixes` is defined, `["tt"]` will match this request, but something different (e.g. `["yt_id:"]`) won't. This helps you ensure your addon does not get irrelevant requests.
 
 For the full spec, see [manifest - filtering properties](./responses/manifest.md#filtering-properties).

--- a/docs/api/requests/defineCatalogHandler.md
+++ b/docs/api/requests/defineCatalogHandler.md
@@ -31,7 +31,7 @@ The resolving object can also include the following cache related properties:
 
 ## Extra Parameters
 
-If you wish to use these parameters, you'll need to specify them in `extra` for the catalog in the [add-on manifest](../responses/manifest.md#extra-properties)
+If you wish to use these parameters, you'll need to specify them in `extra` for the catalog in the [addon manifest](../responses/manifest.md#extra-properties)
 
 ``search`` - set in the `extra` object; string to search for in the catalog
 

--- a/docs/api/requests/defineResourceHandler.md
+++ b/docs/api/requests/defineResourceHandler.md
@@ -1,6 +1,6 @@
 ## defineResourceHandler
 
-This method currently handles add-on catalog requests. As opposed to `defineCatalogHandler()` which handles meta catalogs, this method handles catalogs of add-on manifests. This means that an add-on can be used to just pass a list of other add-ons that can be installed in Stremio.
+This method currently handles addon catalog requests. As opposed to `defineCatalogHandler()` which handles meta catalogs, this method handles catalogs of addon manifests. This means that an addon can be used to just pass a list of other addons that can be installed in Stremio.
 
 
 ### Arguments:
@@ -9,7 +9,7 @@ This method currently handles add-on catalog requests. As opposed to `defineCata
 
 ### Returns:
 
-A promise that resolves to an object containing `{ addons: [] }` with an array of [Catalog Add-on Object](../responses/addon_catalog.md)
+A promise that resolves to an object containing `{ addons: [] }` with an array of [Catalog Addon Object](../responses/addon_catalog.md)
 
 The resolving object can also include the following cache related properties:
 
@@ -52,4 +52,4 @@ builder.defineResourceHandler('addon_catalog', function(args) {
 })
 ```
 
-[Catalog Add-on Object Definition](../responses/addon_catalog.md)
+[Catalog Addon Object Definition](../responses/addon_catalog.md)

--- a/docs/api/responses/addon_catalog.md
+++ b/docs/api/responses/addon_catalog.md
@@ -1,9 +1,9 @@
-## Add-on Catalog Object
+## Addon Catalog Object
 
 Used as a response for [`defineResourceHandler`](../requests/defineResourceHandler.md)
 
 ### Properties
 
 * ``transportName`` - **required** - string, only `http` is currently officially supported
-* ``transportUrl`` - **required** - string, the URL of the add-on's `manifest.json` file
-* ``manifest`` - **required** - object representing the add-on's [Manifest Object](./manifest.md)
+* ``transportUrl`` - **required** - string, the URL of the addon's `manifest.json` file
+* ``manifest`` - **required** - object representing the addon's [Manifest Object](./manifest.md)

--- a/docs/api/responses/manifest.md
+++ b/docs/api/responses/manifest.md
@@ -1,6 +1,6 @@
 ### Manifest format
 
-The first thing to define for your add-on is the manifest, which describes it's name, purpose and some technical details.
+The first thing to define for your addon is the manifest, which describes it's name, purpose and some technical details.
 
 Valid properties are:
 
@@ -13,18 +13,18 @@ Valid properties are:
 
 ``description`` - **required** - string, human readable description
 
-``version`` - **required** - string, [semantic version](https://semver.org/) of the add-on
+``version`` - **required** - string, [semantic version](https://semver.org/) of the addon
 
 
 ## Filtering properties
 
-**NOTE:** In order to understand the next properties better, please check out the [protocol documentation](../../protocol.md) and keep in mind requests to add-ons are formed in the format of `/{resource}/{type}/{id}`
+**NOTE:** In order to understand the next properties better, please check out the [protocol documentation](../../protocol.md) and keep in mind requests to addons are formed in the format of `/{resource}/{type}/{id}`
 
 ``resources`` - **required** - array of objects or strings, supported resources - for example ``["catalog", "meta", "stream", "subtitles", "addon_catalog"]``, resources can also be added as objects instead of strings, for additional details on how they should be requested, example: `{ "name": "stream", "type": "movie", "idPrefixes": [ "tt" ] }` (see the **ADVANCED** note)
 
 ``types`` - **required** - array of strings, supported types, from all the [``Content Types``](./content.types.md). If you wish to provide different sets of types for different resources, see the **ADVANCED** note.
 
-``idPrefixes`` - _optional_ - array of strings, use this if you want your add-on to be called only for specific content IDs - for example, if you set this to `["yt_id:", "tt"]`, your add-on will only be called for `id` values that start with `yt_id:` or `tt`. If you wish to provide different sets of `idPrefixes` for different resources, see the **ADVANCED** note.
+``idPrefixes`` - _optional_ - array of strings, use this if you want your addon to be called only for specific content IDs - for example, if you set this to `["yt_id:", "tt"]`, your addon will only be called for `id` values that start with `yt_id:` or `tt`. If you wish to provide different sets of `idPrefixes` for different resources, see the **ADVANCED** note.
 
 ### Advanced
 
@@ -42,15 +42,15 @@ Please note, the `idPrefixes` filtering does not matter for the `"catalog"` reso
 
 ## Content catalogs
 
-**NOTE:** Leave this an empty array (``[]``) if your add-on does not provide the `catalog` resource.
+**NOTE:** Leave this an empty array (``[]``) if your addon does not provide the `catalog` resource.
 
-``catalogs`` - **required** - array of [``Catalog objects``](#catalog-format), a list of the content catalogs your add-on provides
+``catalogs`` - **required** - array of [``Catalog objects``](#catalog-format), a list of the content catalogs your addon provides
 
 ### Catalog format
 
 ``type`` - **required** - string, this is the content type of the catalog
 
-``id`` - **required** - string, the id of the catalog, can be any unique string describing the catalog (unique per add-on, as an add-on can have many catalogs), for example: if the catalog name is "Favourite Youtube Videos", the id can be `"fav_youtube_videos"`
+``id`` - **required** - string, the id of the catalog, can be any unique string describing the catalog (unique per addon, as an addon can have many catalogs), for example: if the catalog name is "Favourite Youtube Videos", the id can be `"fav_youtube_videos"`
 
 ``name`` - **required** - string, human readable name of the catalog
 
@@ -82,29 +82,29 @@ For a complete list of extra catalog properties that Stremio pays attention to, 
 
 If you're looking for the legacy way of setting extra properties (also called "short"), [check out the old docs](https://github.com/Stremio/stremio-addon-sdk/blob/b11bd517f8ce3b24a843de320ec8ac193611e9a0/docs/api/responses/manifest.md#catalog-format)
 
-## Add-on catalogs
+## Addon catalogs
 
-``addonCatalogs`` - _optional_ - array of [``Catalog objects``](#addon-catalog-format), a list of other add-on manifests, this can be used for an add-on to act just as a catalog of other add-ons.
+``addonCatalogs`` - _optional_ - array of [``Catalog objects``](#addon-catalog-format), a list of other addon manifests, this can be used for an addon to act just as a catalog of other addons.
 
-### Add-on Catalog format
+### Addon Catalog format
 
 ``type`` - **required** - string, this is the content type of the catalog
 
-``id`` - **required** - string, the id of the catalog, can be any unique string describing the catalog (unique per add-on, as an add-on can have many catalogs), for example: if the catalog name is "Favourite Youtube Videos", the id can be `"fav_youtube_videos"`
+``id`` - **required** - string, the id of the catalog, can be any unique string describing the catalog (unique per addon, as an addon can have many catalogs), for example: if the catalog name is "Favourite Youtube Videos", the id can be `"fav_youtube_videos"`
 
 ``name`` - **required** - string, human readable name of the catalog
 
 ## Other metadata
 
-``background`` - _optional_ - string, background image for the add-on; URL to png/jpg, at least 1024x786 resolution
+``background`` - _optional_ - string, background image for the addon; URL to png/jpg, at least 1024x786 resolution
 
 ``logo`` - _optional_ - string, logo icon, URL to png, monochrome, 256x256
 
-``contactEmail`` - _optional_ - string, contact email for add-on issues; used for the Report button in the app; also, the Stremio team may reach you on this email for anything relating your add-on
+``contactEmail`` - _optional_ - string, contact email for addon issues; used for the Report button in the app; also, the Stremio team may reach you on this email for anything relating your addon
 
 ``behaviorHints`` - _all are optional_ - object, supports the properties:
 
-- ``adult`` - boolean, if the add-on includes adult content, default is `false`
+- ``adult`` - boolean, if the addon includes adult content, default is `false`
 
 
 ***TIP* - to implement sources where streams are geo-restricted, see [``Stream objects``](./stream.md) `geos`**
@@ -116,8 +116,8 @@ If you're looking for the legacy way of setting extra properties (also called "s
 {           
     "id": "org.stremio.example",
     "version": "0.0.1",
-    "description": "Example Stremio Add-on",
-    "name": "Example Add-on",
+    "description": "Example Stremio Addon",
+    "name": "Example Addon",
     "resources": [
         "catalog",
         "stream"
@@ -136,7 +136,7 @@ If you're looking for the legacy way of setting extra properties (also called "s
 }
 ```
 
-This manifest example is for an add-on that:
+This manifest example is for an addon that:
 - provides streams and catalogs
 - has one catalog that includes movies
 - will receive stream requests for meta items that have an id that starts with `tt` (imdb id, example: `tt0068646`), for both movies and series

--- a/docs/api/responses/meta.links.md
+++ b/docs/api/responses/meta.links.md
@@ -4,7 +4,7 @@
 
 * ``stremio:///search?search=${query}`` - opens the Search page with the set `${query}`
 
-* ``stremio:///discover/${transportUrl}/${type}/${catalogId}?${extra}`` - opens the Discover page for the add-on that has `${transportUrl}` (URL to an add-on's [``Manifest``](./manifest.md)), with the [``Catalog``](./manifest.md#catalog-format) which has the id `${catalogId}` and the type `${type}`, the `?${extra}` is optional and refers to [``Catalog Extra Parameters``](../requests/defineCatalogHandler.md#extra-parameters) that should be passed as a [``Query String``](https://en.wikipedia.org/wiki/Query_string)
+* ``stremio:///discover/${transportUrl}/${type}/${catalogId}?${extra}`` - opens the Discover page for the addon that has `${transportUrl}` (URL to an addon's [``Manifest``](./manifest.md)), with the [``Catalog``](./manifest.md#catalog-format) which has the id `${catalogId}` and the type `${type}`, the `?${extra}` is optional and refers to [``Catalog Extra Parameters``](../requests/defineCatalogHandler.md#extra-parameters) that should be passed as a [``Query String``](https://en.wikipedia.org/wiki/Query_string)
 
 * ``stremio:///metadetail/${type}/${id}`` - opens the Detail page for the [``Meta Object``](./meta.md) with the id `${id}` and the type `${type}`
 

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -2,7 +2,7 @@
 
 Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
-``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your add-on, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
+``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your addon, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
 
 ``type`` - **required** - string, type of the content; e.g. `movie`, `series`, `channel`, `tv` (see [Content Types](./content.types.md))
 
@@ -66,9 +66,9 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``thumbnail`` - _optional_ - string, URL to png of the video thumbnail, in the video's aspect ratio, max file size 5kb
 
-``streams`` - _optional_ - array of [``Stream Objects``](./stream.md), in case you can return links to streams while forming meta response, **you can pass and array of [``Stream Objects``](./stream.md)** to point the video to a HTTP URL, BitTorrent, YouTube or any other stremio-supported transport protocol; note that this is exclsuive: passing `video.streams` means that **Stremio will not** request any streams from other add-ons for that video; if you return streams that way, it is still recommended to implement the `streams` resource
+``streams`` - _optional_ - array of [``Stream Objects``](./stream.md), in case you can return links to streams while forming meta response, **you can pass and array of [``Stream Objects``](./stream.md)** to point the video to a HTTP URL, BitTorrent, YouTube or any other stremio-supported transport protocol; note that this is exclsuive: passing `video.streams` means that **Stremio will not** request any streams from other addons for that video; if you return streams that way, it is still recommended to implement the `streams` resource
 
-``available`` - _optional_ - boolean, set to ``true`` to explicitly state that this video is available for streaming, from your add-on; no need to use this if you've passed ``stream``
+``available`` - _optional_ - boolean, set to ``true`` to explicitly state that this video is available for streaming, from your addon; no need to use this if you've passed ``stream``
 
 ``episode`` - _optional_ - number, episode number, if applicable
 
@@ -92,7 +92,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 }
 ```
 
-You can see a comprehensive example of how detailed Meta objects with videos are returned [here, on the Cinemeta add-on](https://v3-cinemeta.strem.io/meta/series/tt0386676/lastVideos=1.json)
+You can see a comprehensive example of how detailed Meta objects with videos are returned [here, on the Cinemeta addon](https://v3-cinemeta.strem.io/meta/series/tt0386676/lastVideos=1.json)
 
 ##### Video object - YouTube video example (channels)
 
@@ -112,7 +112,7 @@ This is a shorter variant of the previously described [Meta Object](#meta-object
 
 Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler.md)
 
-``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your add-on, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
+``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your addon, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
 
 ``type`` - **required** - string, type of the content; e.g. `movie`, `series`, `channel`, `tv` (see [Content Types](./content.types.md))
 

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -6,7 +6,7 @@ Stremio supports two types of deep links through the `stremio://` protocol
 
 ## To addons
 
-Simply take a normal URL to a Stremio add-on manifest, e.g. `https://watchhub-us.strem.io/manifest.json`, and replace the leading `https://` with `stremio://`
+Simply take a normal URL to a Stremio addon manifest, e.g. `https://watchhub-us.strem.io/manifest.json`, and replace the leading `https://` with `stremio://`
 
 E.g. [stremio://watchhub-us.strem.io/manifest.json](stremio://watchhub-us.strem.io/manifest.json)
 
@@ -34,9 +34,9 @@ Discover does not support deeper linking for now.
 
 * `videoID` is the [video object ID](./api/responses/meta.md#video-object); leave this empty if you only wish to show the list of episodes/videos (not applicable for one-video types, such as `movie` and `tv`)
 
-In the Cinemeta add-on, the `videoID` is the same as the `id` for movies, and for series it's formed as `{id}:{season}:episode`
+In the Cinemeta addon, the `videoID` is the same as the `id` for movies, and for series it's formed as `{id}:{season}:episode`
 
-In the Channels add-on, the `videoID` is formed as `{id}:{youtube video ID}`
+In the Channels addon, the `videoID` is formed as `{id}:{youtube video ID}`
 
 Examples:
 

--- a/docs/deploying/README.md
+++ b/docs/deploying/README.md
@@ -1,8 +1,8 @@
-## Deploying your Add-on
+## Deploying your Addon
 
-**Note:** Although deploying is recommended, there is also the alternative of using [localtunnel](https://github.com/localtunnel/localtunnel) to host your add-ons locally.
+**Note:** Although deploying is recommended, there is also the alternative of using [localtunnel](https://github.com/localtunnel/localtunnel) to host your addons locally.
 
-Stremio add-ons require hosting in order to be published. You will need a NodeJS hosting solution, as Stremio Add-ons made with the Stremio Add-on SDK are NodeJS apps.
+Stremio addons require hosting in order to be published. You will need a NodeJS hosting solution, as Stremio Addons made with the Stremio Addon SDK are NodeJS apps.
 
 We recommend:
 
@@ -16,15 +16,15 @@ We hugely recomment using `Now.sh`, as it is extremely easy to use.
 
 You can also check this very comprehensive [guide by nodejs](https://github.com/nodejs/node-v0.x-archive/wiki/node-hosting).
 
-Stremio add-ons are deployed just like regular nodejs apps, so follow the nodejs instructions provided by your particular service provider.
+Stremio addons are deployed just like regular nodejs apps, so follow the nodejs instructions provided by your particular service provider.
 
-If you've built a great add-on, and need help with hosting your add-on, you are welcome to contact us at [addons@stremio.com](addons@stremio.com)
+If you've built a great addon, and need help with hosting your addon, you are welcome to contact us at [addons@stremio.com](addons@stremio.com)
 
 ### Publishing to Stremio
 
-If you want your add-on to appear in the list of Community add-ons in Stremio, check out [publishToCentral](../README.md#publishtocentralurl)
+If you want your addon to appear in the list of Community addons in Stremio, check out [publishToCentral](../README.md#publishtocentralurl)
 
-If you are not using the Add-on SDK to create your add-on, you can publish your add-on in the list of Community add-ons in Stremio by submitting it on [this site](https://stremio.github.io/stremio-publish-addon/index.html)
+If you are not using the Addon SDK to create your addon, you can publish your addon in the list of Community addons in Stremio by submitting it on [this site](https://stremio.github.io/stremio-publish-addon/index.html)
 
 ### Guides
 

--- a/docs/deploying/glitch.md
+++ b/docs/deploying/glitch.md
@@ -1,17 +1,17 @@
 # Deploying to Glitch with CloudFlare
 
 The plan:
-- deploy your node.js add-on to [Glitch.com](https://glitch.com)
+- deploy your node.js addon to [Glitch.com](https://glitch.com)
 - create a free domain (for 12 months) on [my.ga](https://my.ga)
 - use [Fly.io](https://fly.io) to connect the custom domain to the glitch project
-- use [CloudFlare](https://cloudflare.com) to cache the add-on responses
+- use [CloudFlare](https://cloudflare.com) to cache the addon responses
 
 
 ## 1. Deploying to Glitch.com
 
 [Glitch](https://glitch.com) offers 4000 requests per hour and sends your app to sleep after 5 minutes of inactivity.
 
-Deploying to Glitch takes seconds if you have your add-on on GitHub, just go on the site, create a new user (if you don't have one already), and import your project based on your Github's Git link (find it by pressing the "Clone or download" button on your Github's project page)
+Deploying to Glitch takes seconds if you have your addon on GitHub, just go on the site, create a new user (if you don't have one already), and import your project based on your Github's Git link (find it by pressing the "Clone or download" button on your Github's project page)
 
 A few pointers:
 - use `process.env.PORT` as your HTTP server's port
@@ -40,7 +40,7 @@ Go on [Fly.io](https://fly.io) and create an account if you don't have one, afte
 Select "Glitch" and enter your Glitch project Live URL. This will bring you to a page that asks you to set DNS records, keep this page open and continue with the tutorial.
 
 
-## 4. Use CloudFlare to cache the add-on responses
+## 4. Use CloudFlare to cache the addon responses
 
 Go to [CloudFlare](cloudflare.com) and create a new account if you don't have one. Then add a new site with the .ga domain you registered in Step 2, CloudFlare will tell you that it couldn't find any DNS records for it, don't worry, that's fine. Create a new CNAME record with the Name set to `@` and the Target set to what the page from Step 3 shows next to CNAME (it should be a URL that ends with `.shw.io`). Now press "Add Rule" and confirm the changes.
 

--- a/docs/deploying/now.md
+++ b/docs/deploying/now.md
@@ -58,7 +58,7 @@ Open a terminal window, go to your project's directory and simply write `now`, t
 
 ## 2. Use Now.sh CDN Caching
 
-It is important to set the `cacheMaxAge` parameter in the responses with the number of seconds you want the responses cached by Now.sh's CDN. Caching is important to reduce the number of requests and ensuring the longevity of your add-on.
+It is important to set the `cacheMaxAge` parameter in the responses with the number of seconds you want the responses cached by Now.sh's CDN. Caching is important to reduce the number of requests and ensuring the longevity of your addon.
 
 The `cacheMaxAge` parameter is documented for all [request handlers](../api/requests).
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,23 +1,23 @@
-# Stremio Add-on Examples
+# Stremio Addon Examples
 
 
 ### Examples using SDK
 
-- [Hello World Add-on](https://github.com/Stremio/addon-helloworld): also includes a step by step tutorial
-- [IGDB Add-on](https://github.com/Stremio/stremio-igdb-addon/tree/tutorial)
+- [Hello World Addon](https://github.com/Stremio/addon-helloworld): also includes a step by step tutorial
+- [IGDB Addon](https://github.com/Stremio/stremio-igdb-addon/tree/tutorial)
 
 ### Examples not using this SDK
 
-- [PHP Add-on Example & Tutorial](https://github.com/Stremio/stremio-php-addon-example)
-- [Go Add-on Example](https://github.com/Stremio/addon-helloworld-go)
-- [Python Add-on Example & Tutorial](https://github.com/Stremio/addon-helloworld-python)
-- [Ruby Add-on Example & Tutorial](https://github.com/Stremio/addon-helloworld-ruby)
-- [C# Add-on Example](https://github.com/Stremio/addon-helloworld-csharp)
-- [Node.js Express Add-on Example & Tutorial](https://github.com/Stremio/addon-helloworld-express)
-- [Node.js Express Add-on Example Using User Data](./advanced.md)
-- [IMDB Lists - Node.js Express Add-on Using User Data and Ajax Calls](https://github.com/jaruba/stremio-imdb-list)
-- [IMDB Watchlist - Node.js Express Add-on Using User Data and Proxying Another Stremio Add-on](https://github.com/jaruba/stremio-imdb-watchlist)
-- [Jackett Add-on - Node.js Express Add-on Using User Data](https://github.com/BoredLama/stremio-jackett-addon)
+- [PHP Addon Example & Tutorial](https://github.com/Stremio/stremio-php-addon-example)
+- [Go Addon Example](https://github.com/Stremio/addon-helloworld-go)
+- [Python Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-python)
+- [Ruby Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-ruby)
+- [C# Addon Example](https://github.com/Stremio/addon-helloworld-csharp)
+- [Node.js Express Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-express)
+- [Node.js Express Addon Example Using User Data](./advanced.md)
+- [IMDB Lists - Node.js Express Addon Using User Data and Ajax Calls](https://github.com/jaruba/stremio-imdb-list)
+- [IMDB Watchlist - Node.js Express Addon Using User Data and Proxying Another Stremio Addon](https://github.com/jaruba/stremio-imdb-watchlist)
+- [Jackett Addon - Node.js Express Addon Using User Data](https://github.com/BoredLama/stremio-jackett-addon)
 
 
 ### Guides
@@ -28,4 +28,4 @@
 
 ### Video tutorials
 
-- [Building a Stremio add-on](https://www.youtube.com/watch?v=HqTkQeRKF-c&list=PLhslIqdUyoB-8olXVaYQxDLJIIOcSQU3H)
+- [Building a Stremio addon](https://www.youtube.com/watch?v=HqTkQeRKF-c&list=PLhslIqdUyoB-8olXVaYQxDLJIIOcSQU3H)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,19 +1,19 @@
 
-## Stremio Add-on Protocol
+## Stremio Addon Protocol
 
-**If you're creating an add-on, we recommend you build it using our [addon-sdk](https://github.com/Stremio/stremio-addon-sdk), which will provide a convenient abstraction to the protocol, as well as an easy way of publishing your add-ons.**
+**If you're creating an addon, we recommend you build it using our [addon-sdk](https://github.com/Stremio/stremio-addon-sdk), which will provide a convenient abstraction to the protocol, as well as an easy way of publishing your addons.**
 
 The Stremio addon protocol defines a universal interface to describe multimedia content. It can describe catalogs, detailed metadata and streams related to multimedia content.
 
 It is typically transported over HTTP or IPFS, and follows a paradigm similar to REST.
 
-This allows Stremio or other similar applications to aggregate content seamlessly from different sources, for example YouTube, Twitch, iTunes, Netflix, DTube and others. It also allows developers to build such add-ons with minimal skill.
+This allows Stremio or other similar applications to aggregate content seamlessly from different sources, for example YouTube, Twitch, iTunes, Netflix, DTube and others. It also allows developers to build such addons with minimal skill.
 
-To define a minimal add-on, you only need an HTTP server/endpoint serving a `/manifest.json` file and responding to resource requests at `/{resource}/{type}/{id}.json`.
+To define a minimal addon, you only need an HTTP server/endpoint serving a `/manifest.json` file and responding to resource requests at `/{resource}/{type}/{id}.json`.
 
 Currently used resources are: `catalog`, `meta`, `stream`, `subtitles`.
 
-`/catalog/{type}/{id}.json` - catalogs of media items; `type` denotes the type, such as `movie`, `series`, `channel`, `tv`, and `id` denotes the catalog ID, which is custom and specified in your manifest, `id` is required as an add-on can hold multiple catalogs
+`/catalog/{type}/{id}.json` - catalogs of media items; `type` denotes the type, such as `movie`, `series`, `channel`, `tv`, and `id` denotes the catalog ID, which is custom and specified in your manifest, `id` is required as an addon can hold multiple catalogs
 
 `/meta/{type}/{id}.json` - detailed metadata about a particular item; `type` again denotes the type, and `id` is the ID of the particular item, as found in the catalog
 
@@ -27,15 +27,15 @@ To pass extra args, such as the ones needed for `catalog` resources (e.g. `searc
 
 For the HTTP transport, each route, including `/manifest.json`, must serve CORS headers that allow all origins.
 
-**NOTE: Your add-on may selectively provide any number of resources. It must provide at least 1 resource and a manifest.**
+**NOTE: Your addon may selectively provide any number of resources. It must provide at least 1 resource and a manifest.**
 
 ## Transports, URLs
 
-The abstractions that are used to actually request data from add-ons are called "transports".
+The abstractions that are used to actually request data from addons are called "transports".
 
 A client library normally implements the following transports: HTTP, legacy and IPFS. "legacy" is a special type of transport that maps the resource requests (in the form of `{ resource, type, id, extraArgs }`) to requests to the legacy v1/v2 versions of the addon protocol.
 
-"Transport URL" refers to the URL to the add-on. Depending on the protocol of the URL and suffix of the pathname, the relevant transport will be selected:
+"Transport URL" refers to the URL to the addon. Depending on the protocol of the URL and suffix of the pathname, the relevant transport will be selected:
 
 * `https://.../manifest.json`: HTTP transport
 * `https://.../stremio/v1`: legacy transport
@@ -71,8 +71,8 @@ Create a directory called `example-addon`
 [Manifest Object Definition](./api/responses/manifest.md)
 
 In this simple example, we set the id prefix of the streams to `tt`, which is the prefix for IMDB IDs (example: `tt1254207`).
-Because we're using IMDB IDs, we do not need to handle the Meta requests, as all IMDB IDs from all add-ons are handled
-internally by Stremio's Cinemeta Add-on.
+Because we're using IMDB IDs, we do not need to handle the Meta requests, as all IMDB IDs from all addons are handled
+internally by Stremio's Cinemeta Addon.
 
 
 `/catalog/movie/bbbcatalog.json`:
@@ -113,13 +113,13 @@ internally by Stremio's Cinemeta Add-on.
 
 [Stream Object Definition](./api/responses/stream.md)
 
-That's it! By handling "catalog" and "stream" with the IMDB ID prefix ("tt"), we have a complete add-on serving just one stream
+That's it! By handling "catalog" and "stream" with the IMDB ID prefix ("tt"), we have a complete addon serving just one stream
 for Big Buck Bunny that has it's own catalog that has only Big Buck Bunny in it. Also, because this is based on IMDB ID, the
-stream will also be available if users open Big Buck Bunny from other add-ons that use IMDB IDs too.
+stream will also be available if users open Big Buck Bunny from other addons that use IMDB IDs too.
 
 
-If we were to also want subtitles for this add-on, we could add: `{ "name": "subtitles", "type": "movie", idPrefixes: [ "tt" ] }`
-to the add-on manifest's `resources` and then handle subtitle requests with:
+If we were to also want subtitles for this addon, we could add: `{ "name": "subtitles", "type": "movie", idPrefixes: [ "tt" ] }`
+to the addon manifest's `resources` and then handle subtitle requests with:
 
 `/subtitle/movie/tt1254207.json`:
 
@@ -140,7 +140,7 @@ to the add-on manifest's `resources` and then handle subtitle requests with:
 
 Alternatively, if we were to not use the IMDB ID prefix ("tt"), and would use a different prefix, such as "exampleid", then "Big Buck
 Bunny" would have a presumable ID of "exampleid1". In this case, we could add `{ "name": "meta", "type": "movie", idPrefixes: [ "exampleid" ]}`
-to the add-on manifest's `resources` and then handle meta requests too with:
+to the addon manifest's `resources` and then handle meta requests too with:
 
 
 `/meta/movie/exampleid1.json`:
@@ -164,9 +164,9 @@ Meta requests are done when Stremio opens a Details page for a movie (series, ch
 ID prefix, as that is handled internally by Stremio.
 
 
-This add-on is so simple that it can actually be hosted statically on GitHub pages!
+This addon is so simple that it can actually be hosted statically on GitHub pages!
 
-[See Example Static Add-on](https://github.com/Stremio/stremio-static-addon-example)
+[See Example Static Addon](https://github.com/Stremio/stremio-static-addon-example)
 
 
 ## Objects
@@ -184,11 +184,11 @@ Check out the following tutorials for different languages:
 
 **If in doubt, and you know JavaScript, use the Node.js SDK**
 
-* [Creating an add-on with the NodeJS Stremio Add-on SDK](https://github.com/Stremio/addon-helloworld)
-* [Creating an add-on with NodeJS and express](https://github.com/Stremio/addon-helloworld-express)
-* [Creating an add-on with PHP](https://github.com/Stremio/stremio-php-addon-example)
-* [Creating an add-on with Python](https://github.com/stremio/addon-helloworld-python)
-* [Creating an add-on with Ruby](https://github.com/stremio/addon-helloworld-ruby)
-* [Creating an add-on with Go](https://github.com/stremio/addon-helloworld-go)
-* [Creating an add-on with C#](https://github.com/stremio/addon-helloworld-csharp)
-* [Creating an add-on with Java](https://github.com/stremio/addon-helloworld-java)
+* [Creating an addon with the NodeJS Stremio Addon SDK](https://github.com/Stremio/addon-helloworld)
+* [Creating an addon with NodeJS and express](https://github.com/Stremio/addon-helloworld-express)
+* [Creating an addon with PHP](https://github.com/Stremio/stremio-php-addon-example)
+* [Creating an addon with Python](https://github.com/stremio/addon-helloworld-python)
+* [Creating an addon with Ruby](https://github.com/stremio/addon-helloworld-ruby)
+* [Creating an addon with Go](https://github.com/stremio/addon-helloworld-go)
+* [Creating an addon with C#](https://github.com/stremio/addon-helloworld-csharp)
+* [Creating an addon with Java](https://github.com/stremio/addon-helloworld-java)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
-## Testing your Add-on
+## Testing your Addon
 
-To test your add-on, you will need to add the add-on manifest URL to a client.
+To test your addon, you will need to add the addon manifest URL to a client.
 
 There are currently two such clients that you can test with:
 
@@ -8,16 +8,16 @@ There are currently two such clients that you can test with:
 
 - Stremio Web Version
 
-**Note:** if you want to load an add-on by URL in Stremio, the URL must either be accessed on `127.0.0.1` or support HTTPS.
+**Note:** if you want to load an addon by URL in Stremio, the URL must either be accessed on `127.0.0.1` or support HTTPS.
 
 
 ### Starting/launching shortcuts
 
 If you're using the [`serveHTTP`](/docs/README.md#servehttpaddoninterface-options) method, there are two shortcuts that you can use:
 
-If you launch your add-on with `npm start -- --launch`, it will open a web version of Stremio with the add-on pre-installed.
+If you launch your addon with `npm start -- --launch`, it will open a web version of Stremio with the addon pre-installed.
 
-Another shortcut is to use `npm start -- --install`, which will open the desktop version of Stremio and a prompt to install the add-on.
+Another shortcut is to use `npm start -- --install`, which will open the desktop version of Stremio and a prompt to install the addon.
 
 
 ### Testing in Stremio App
@@ -29,12 +29,12 @@ Testing in Stremio is easy, simply [download Stremio](https://www.stremio.com/do
 
 Open the web version of Stremio at: https://app.strem.io/shell-v4.4/
 
-If you use `npm start -- --launch`, the add-on will launch at https://staging.strem.io, which is a staging (development) version of Stremio.
+If you use `npm start -- --launch`, the addon will launch at https://staging.strem.io, which is a staging (development) version of Stremio.
 
 **Note: Torrents will not work in Stremio's Web Version.**
 
 
-### How to Install Add-on in Stremio
+### How to Install Addon in Stremio
 
 Follow the 2 steps showcased in this image:
 

--- a/examples/from-readme.js
+++ b/examples/from-readme.js
@@ -7,8 +7,8 @@ const builder = new addonBuilder({
 
 	name: 'simple example',
 
-	// Properties that determine when Stremio picks this add-on
-	// this means your add-on will be used for streams of the type movie
+	// Properties that determine when Stremio picks this addon
+	// this means your addon will be used for streams of the type movie
 	catalogs: [],
 	resources: ['stream'],
 	types: ['movie'],


### PR DESCRIPTION
Based on an internal decision to call them "addon" from now on.