### PR TITLE
Add 3rd party Rust SDK to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ Environment variables:
 
 ## Examples & tutorials
 
-Check out our ever growing list of [examples and demo addons](./docs/examples.md). This list also includes examples & tutorials on how to develop Stremio addons in PHP, Python, Ruby, C#, Java and Go. It also includes a list of video tutorials.
+Check out our ever growing list of [examples and demo addons](./docs/examples.md). This list also includes examples & tutorials on how to develop Stremio addons in PHP, Python, Ruby, C#, Rust, Java and Go. It also includes a list of video tutorials.
 
+### Rust version
+There is a third-party Rust version of this SDK built on stremio-core developed by Sleeyax [here](https://github.com/sleeyax/stremio-addon-sdk).
 
 ## Advanced Usage
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -13,6 +13,7 @@
 - [Python Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-python)
 - [Ruby Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-ruby)
 - [C# Addon Example](https://github.com/Stremio/addon-helloworld-csharp)
+- [Rust Addon Example Using Unofficial SDK](https://github.com/sleeyax/stremio-addon-sdk/tree/master/example-addon)
 - [Node.js Express Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-express)
 - [Node.js Express Addon Example Using User Data](./advanced.md)
 - [IMDB Lists - Node.js Express Addon Using User Data and Ajax Calls](https://github.com/jaruba/stremio-imdb-list)


### PR DESCRIPTION
The Rust port is mature enough to be used in production now, so here is the PR that adds it to the docs [as discussed](https://github.com/Stremio/stremio-core/issues/30#issuecomment-570777156).