### PR TITLE
Move landing template route to router

### DIFF
--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -1,7 +1,7 @@
 const Router = require('router')
 const qs = require('querystring')
 const cors = require('cors')
-const landingTemplate = require('./landingTemplate');
+const landingTemplate = require('./landingTemplate')
 
 function getRouter({ manifest , get }) {
 	const router = new Router()

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -1,12 +1,20 @@
 const Router = require('router')
 const qs = require('querystring')
 const cors = require('cors')
+const landingTemplate = require('./landingTemplate');
 
 function getRouter({ manifest , get }) {
 	const router = new Router()
 
 	// CORS is mandatory for the addon protocol
 	router.use(cors())
+
+	// Show landing page at '/'
+	const landingHTML = landingTemplate(manifest)
+	router.get('/', function(req, res) {
+		res.setHeader('content-type', 'text/html')
+		res.end(landingHTML)
+	})
 
 	// Serve the manifest
 	const manifestBuf = JSON.stringify(manifest)

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const fs = require('fs')
 const path = require('path')
-const landingTemplate = require('./landingTemplate')
 const getRouter = require('./getRouter')
 const opn = require('opn')
 

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -30,13 +30,6 @@ function serveHTTP(addonInterface, opts = {}) {
 		app.use(opts.static, express.static(location))
 	}
 
-	// landing page
-	const landingHTML = landingTemplate(addonInterface.manifest)
-	app.get('/', (_, res) => {
-		res.setHeader('content-type', 'text/html')
-		res.end(landingHTML)
-	})
-
 	const server = app.listen(opts.port)
 	return new Promise(function(resolve, reject) {
 		server.on('listening', function() {


### PR DESCRIPTION
Currently the landing template route is only defined in `serveHTTP.js`:
```
// landing page
const landingHTML = landingTemplate(addonInterface.manifest)
app.get('/', (_, res) => {
	res.setHeader('content-type', 'text/html')
	res.end(landingHTML)
})
```

It makes more sense to move this to `getRouter`.