### PR TITLE
update meta behaviorHints.defaultVideo docs

### DIFF
--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -44,7 +44,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``behaviorHints`` - _all are optional_ - object, supports the properties:
 
-- ``defaultVideo`` - boolean, set to a [``Video Object``](#video-object) id in order to open the Detail page directly to that video's streams
+- ``defaultVideoId`` - string, set to a [``Video Object``](#video-object) id in order to open the Detail page directly to that video's streams
 
 
 #### Meta Link object


### PR DESCRIPTION
Changes `behaviorHints.defaultVideo` to `behaviorHints.defaultVideoId` and correct the docs as it is actually a `string` (not a `boolean`)