### PR TITLE
Update Meta Preview Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ Handles catalog requests, including search.
 
 #### `builder.defineMetaHandler(function handler(args) { })`
 
-Handles metadata requests. (title, year, poster, background, etc.)
+Handles metadata requests. (title, releaseInfo, poster, background, etc.)
 
 [Meta Request Parameters and Example](./api/requests/defineMetaHandler.md)
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -77,7 +77,7 @@ Once you've set `search` in `extra`, your catalog handler will receive `args.ext
 const meta = {
   id: 'tt1254207',
   name: 'Big Buck Bunny',
-  year: 2008,
+  releaseInfo: '2008',
   poster: 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/uVEFQvFMMsg4e6yb03xOfVsDz4o.jpg',
   posterShape: 'regular',
   banner: 'https://image.tmdb.org/t/p/original/aHLST0g8sOE1ixCxRDgM35SKwwp.jpg',
@@ -135,7 +135,7 @@ Now we'll receive `genre` in our catalog handler:
 const meta = {
   id: 'tt1254207',
   name: 'Big Buck Bunny',
-  year: 2008,
+  releaseInfo: '2008',
   poster: 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/uVEFQvFMMsg4e6yb03xOfVsDz4o.jpg',
   posterShape: 'regular',
   banner: 'https://image.tmdb.org/t/p/original/aHLST0g8sOE1ixCxRDgM35SKwwp.jpg',
@@ -214,7 +214,7 @@ Here's an example of using `skip`:
 const meta = {
   id: 'tt1254207',
   name: 'Big Buck Bunny',
-  year: 2008,
+  releaseInfo: '2008',
   poster: 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/uVEFQvFMMsg4e6yb03xOfVsDz4o.jpg',
   posterShape: 'regular',
   banner: 'https://image.tmdb.org/t/p/original/aHLST0g8sOE1ixCxRDgM35SKwwp.jpg',

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,7 +6,7 @@ In order for Stremio to display addon data, the addon must first supply the reso
 | **Resource**  | **Handler** | **Response** | **Description** |
 | ------------- | ------------- | ------------- | ------------- |
 | **manifest** | - | [manifest](./responses/manifest.md) | The addon description and capabilities. |
-| **catalog** | [defineCatalogHandler](./requests/defineCatalogHandler.md) | [meta_preview](./responses/meta.mdmeta.md#meta-preview-object) | Summarized collection of meta preview items. Catalogs are displayed on the Stremio's Board, Discover and Search. |
+| **catalog** | [defineCatalogHandler](./requests/defineCatalogHandler.md) | [meta_preview](./responses/meta.md#meta-preview-object) | Summarized collection of meta preview items. Catalogs are displayed on the Stremio's Board, Discover and Search. |
 | **metadata** | [defineMetaHandler](./requests/defineMetaHandler.md) | [meta](./responses/meta.md) | Detailed description of meta item. This description is displayed when the user selects an item form the catalog. |
 | **streams** | [defineStreamHandler](./requests/defineStreamHandler.md) | [stream](./responses/stream.md) | Tells Stremio how to obtain the media content. It may be torrent info hash, HTTP URL, etc |
 | **subtitles** | [defineSubtitlesHandler](./requests/defineSubtitlesHandler.md) | [subtitles](./responses/subtitles.md) | Subtitles resource for the chosen media. |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,7 +6,7 @@ In order for Stremio to display addon data, the addon must first supply the reso
 | **Resource**  | **Handler** | **Response** | **Description** |
 | ------------- | ------------- | ------------- | ------------- |
 | **manifest** | - | [manifest](./responses/manifest.md) | The addon description and capabilities. |
-| **catalog** | [defineCatalogHandler](./requests/defineCatalogHandler.md) | [meta](./responses/meta.md) | Summarized collection of meta items. Catalogs are displayed on the Stremio's Board, Discover and Search. |
+| **catalog** | [defineCatalogHandler](./requests/defineCatalogHandler.md) | [meta_preview](./responses/meta.mdmeta.md#meta-preview-object) | Summarized collection of meta preview items. Catalogs are displayed on the Stremio's Board, Discover and Search. |
 | **metadata** | [defineMetaHandler](./requests/defineMetaHandler.md) | [meta](./responses/meta.md) | Detailed description of meta item. This description is displayed when the user selects an item form the catalog. |
 | **streams** | [defineStreamHandler](./requests/defineStreamHandler.md) | [stream](./responses/stream.md) | Tells Stremio how to obtain the media content. It may be torrent info hash, HTTP URL, etc |
 | **subtitles** | [defineSubtitlesHandler](./requests/defineSubtitlesHandler.md) | [subtitles](./responses/subtitles.md) | Subtitles resource for the chosen media. |

--- a/docs/api/requests/defineCatalogHandler.md
+++ b/docs/api/requests/defineCatalogHandler.md
@@ -85,4 +85,4 @@ builder.defineCatalogHandler(function(args) {
 })
 ```
 
-[Meta Object Definition](../responses/meta.md)
+[Meta Preview Object Definition](../responses/meta.md#meta-preview-object)

--- a/docs/api/requests/defineCatalogHandler.md
+++ b/docs/api/requests/defineCatalogHandler.md
@@ -53,7 +53,7 @@ builder.defineCatalogHandler(function(args) {
         const meta = {
             id: 'tt1254207',
             name: 'Big Buck Bunny',
-            year: 2008,
+            releaseInfo: '2008',
             poster: 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/uVEFQvFMMsg4e6yb03xOfVsDz4o.jpg',
             posterShape: 'regular',
             banner: 'https://image.tmdb.org/t/p/original/aHLST0g8sOE1ixCxRDgM35SKwwp.jpg',

--- a/docs/api/requests/defineMetaHandler.md
+++ b/docs/api/requests/defineMetaHandler.md
@@ -1,6 +1,6 @@
 ## defineMetaHandler
 
-This method handles metadata requests. (title, year, poster, background, etc.)
+This method handles metadata requests. (title, releaseInfo, poster, background, etc.)
 
 ### Arguments:
 
@@ -35,7 +35,7 @@ builder.defineMetaHandler(function(args) {
         const metaObj = {
             id: 'tt1254207',
             name: 'Big Buck Bunny',
-            year: 2008,
+            releaseInfo: '2008',
             poster: 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/uVEFQvFMMsg4e6yb03xOfVsDz4o.jpg',
             posterShape: 'regular',
             type: 'movie'

--- a/docs/api/requests/defineStreamHandler.md
+++ b/docs/api/requests/defineStreamHandler.md
@@ -47,4 +47,4 @@ builder.defineStreamHandler(function(args) {
 
 [Stream Object Definition](../responses/stream.md)
 
-_Note: You may require additional metadata for the requested item (such as name, year, etc), if the requested ID is a IMDB ID (Cinemeta, for example, uses only IMDB IDs), then please refer to [Getting Metadata from Cinemeta](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/advanced.md#getting-metadata-from-cinemeta) for this purpose._
+_Note: You may require additional metadata for the requested item (such as name, releaseInfo, etc), if the requested ID is a IMDB ID (Cinemeta, for example, uses only IMDB IDs), then please refer to [Getting Metadata from Cinemeta](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/advanced.md#getting-metadata-from-cinemeta) for this purpose._

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -124,7 +124,7 @@ Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler
 
 ``posterShape`` - _optional_ - string, can be `square` (1:1 aspect) or `regular` (1:0.675) or `landscape` (1:1.77). If you don't pass this, `regular` is assumed
 
-##### Additional Parameters that are used for the Discover Page Sidebar
+#### Additional Parameters that are used for the Discover Page Sidebar:
 
 ``background`` - _optional_ - string, the background shown on the stremio discover page in the sidebar; URL to PNG, max file size 500kb
 

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -76,7 +76,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``season`` - _optional_ - number, season number, if applicable
 
-``trailers`` - _optional_ - array, containing [``Stream Objects``](./stream.md))
+``trailers`` - _optional_ - array, containing [``Stream Objects``](./stream.md)
 
 ``overview`` - _optional_ - string, video overview/summary
 

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -28,6 +28,8 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``released`` - _optional_ - string, ISO 8601, initial release date; for movies, this is the cinema debut, e.g. "2010-12-06T05:00:00.000Z"
 
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube ID and `type` can be either `Trailer` or `Clip`
+
 ``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
 
 ``videos`` - _optional_ - array of [``Video objects``](#video-object), used for ``channel`` and ``series``; if you do not provide this (e.g. for ``movie``), Stremio assumes this meta item has one video, and it's ID is equal to the meta item `id`
@@ -122,9 +124,20 @@ Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler
 
 ``posterShape`` - _optional_ - string, can be `square` (1:1 aspect) or `regular` (1:0.675) or `landscape` (1:1.77). If you don't pass this, `regular` is assumed
 
-``background`` - _optional_ - string, the background shown on the stremio detail page ; heavily encouraged if you want your content to look good; URL to PNG, max file size 500kb
+##### Additional Parameters that are used for the Discover Page Sidebar
 
-``logo`` - _optional_ - string, the logo shown on the stremio detail page ; encouraged if you want your content to look good; URL to PNG
+``background`` - _optional_ - string, the background shown on the stremio discover page in the sidebar; URL to PNG, max file size 500kb
+
+``genres`` - _optional_  - array of strings, genre/categories of the content; e.g. ``["Thriller", "Horror"]`` (warning: this will soon be deprecated in favor of ``links``)
+
+``imdbRating`` -  _optional_ - string, IMDb rating, a number from 0.0 to 10.0 ; use if applicable
+
+``releaseInfo`` - _optional_ - string, year the content came out ; if it's ``series`` or ``channel``, use a start and end years split by a tide - e.g. ``"2000-2014"``. If it's still running, use a format like ``"2000-"``
+
+``director``, ``cast`` - _optional_  - directors and cast, both arrays of names (string) (warning: this will soon be deprecated in favor of ``links``)
+
+``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
 
 ``description`` - _optional_ - string, a few sentances describing your content
 
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube ID and `type` can be either `Trailer` or `Clip`

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -28,7 +28,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``released`` - _optional_ - string, ISO 8601, initial release date; for movies, this is the cinema debut, e.g. "2010-12-06T05:00:00.000Z"
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip`
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip` (warning: this will soon be deprecated in favor of `meta.trailers` being an array of [``Stream Objects``](./stream.md))
 
 ``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
 
@@ -76,7 +76,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``season`` - _optional_ - number, season number, if applicable
 
-``trailer`` - _optional_ - string, YouTube ID of the trailer video; use if this is an episode for a series
+``trailers`` - _optional_ - array, containing [``Stream Objects``](./stream.md))
 
 ``overview`` - _optional_ - string, video overview/summary
 
@@ -140,4 +140,4 @@ Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler
 
 ``description`` - _optional_ - string, a few sentances describing your content
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip`
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip` (warning: this will soon be deprecated in favor of `meta.trailers` being an array of [``Stream Objects``](./stream.md))

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -28,7 +28,7 @@ Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
 ``released`` - _optional_ - string, ISO 8601, initial release date; for movies, this is the cinema debut, e.g. "2010-12-06T05:00:00.000Z"
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube ID and `type` can be either `Trailer` or `Clip`
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip`
 
 ``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
 
@@ -140,4 +140,4 @@ Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler
 
 ``description`` - _optional_ - string, a few sentances describing your content
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube ID and `type` can be either `Trailer` or `Clip`
+``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip`

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -120,13 +120,11 @@ Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler
 
 ``name`` - **required** - string, name of the content
 
-``poster`` - **required** - string, URL to png of poster; accepted aspect ratios: 1:0.675 (IMDb poster type) or 1:1 (square) ; you can use any resolution, as long as the file size is below 100kb; below 50kb is recommended
+``poster`` - **required** - string, URL to png of poster; accepted aspect ratios: 1:0.675 (IMDb poster type) or 1:1 (square); you can use any resolution, as long as the file size is below 100kb; below 50kb is recommended; also used as the background shown on the stremio discover page in the sidebar
 
 ``posterShape`` - _optional_ - string, can be `square` (1:1 aspect) or `regular` (1:0.675) or `landscape` (1:1.77). If you don't pass this, `regular` is assumed
 
 #### Additional Parameters that are used for the Discover Page Sidebar:
-
-``background`` - _optional_ - string, the background shown on the stremio discover page in the sidebar; URL to PNG, max file size 500kb
 
 ``genres`` - _optional_  - array of strings, genre/categories of the content; e.g. ``["Thriller", "Horror"]`` (warning: this will soon be deprecated in favor of ``links``)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -160,7 +160,7 @@ to the addon manifest's `resources` and then handle meta requests too with:
 
 [Meta Object Definition](./api/responses/meta.md)
 
-Meta requests are done when Stremio opens a Details page for a movie (series, channel, etc.) The response is used to create the Details page, it can also handle "background", "logo", "year" and other extended information about the movie / series / etc. As previously mentioned, the meta request does not need to be handled at all when using the IMDB
+Meta requests are done when Stremio opens a Details page for a movie (series, channel, etc.) The response is used to create the Details page, it can also handle "background", "logo", "releaseInfo" and other extended information about the movie / series / etc. As previously mentioned, the meta request does not need to be handled at all when using the IMDB
 ID prefix, as that is handled internally by Stremio.
 
 


### PR DESCRIPTION
Improved docs for Meta Preview Objects and added docs for `meta.trailers`.

Relevant issue regarding this PR: https://github.com/Stremio/stremio-addon-sdk/issues/128