### PR TITLE
Add link to Go addon examples using unofficial SDK

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,6 +11,7 @@
 - [PHP Addon Example & Tutorial](https://github.com/Stremio/stremio-php-addon-example)
 - [Laravel (PHP) Addon Template](https://github.com/rleroi/Stremio-Laravel)
 - [Go Addon Example](https://github.com/Stremio/addon-helloworld-go)
+- [Go Addon Examples Using Unofficial SDK](https://github.com/Deflix-tv/go-stremio/tree/master/examples)
 - [Python Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-python)
 - [Ruby Addon Example & Tutorial](https://github.com/Stremio/addon-helloworld-ruby)
 - [C# Addon Example](https://github.com/Stremio/addon-helloworld-csharp)


### PR DESCRIPTION
Hi, the unofficial SDK is already linked on the main README (thanks for that!), but I thought pointing to its examples here could also help with discoverability, similar to the Rust one.