### PR TITLE
Id added in the subtitles object

### DIFF
--- a/docs/api/responses/subtitles.md
+++ b/docs/api/responses/subtitles.md
@@ -2,6 +2,8 @@
 
 Used as a response for [`defineSubtitlesHandler`](../requests/defineSubtitlesHandler.md)
 
+``id`` - **required** - string, unique identifier for each subtitle, if you have more than one subtitle with the same language, the id will differentiate them
+
 ``url`` - **required** - string, url to the subtitle file
 
 ``lang`` - **required** - string, language code for the subtitle, if a valid ISO 639-2 code is not sent, the text of this value will be used instead


### PR DESCRIPTION
If I do not pass the id and there is more than one subtitle with the same language, only one subtitle will be displayed

<img width="518" alt="SubtitleWithoutId" src="https://user-images.githubusercontent.com/60989975/116905524-7c062400-ac15-11eb-921b-c91caa2795df.png">

If the id is filled in, the subtitles will be displayed normally

<img width="518" alt="SubtitleWithId" src="https://user-images.githubusercontent.com/60989975/116905703-b66fc100-ac15-11eb-9467-a66e9fe5d912.png">



