### PR TITLE
Addon User Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ creating a HTTP server to make Stremio Addons. Refer to our [protocol specificat
 
 One useful scenario of not using the SDK is when you need user specific data for you addon (for example, an API
 Autherntication Token), you can see an example of passing user specific data in the Addon URL [here](./docs/advanced.md#using-user-data-in-add-ons).
-This example uses Node.js and Express to get user specific data.
+This example uses Node.js and Express to get user specific data. (Update: the Addon SDK now supports [user settings](./docs/api/responses/manifest.md#user-data))
 
 
 _built with love and serious coding skills by the Stremio Team_

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -331,6 +331,8 @@ Also setting the `type` and `year` in the request helps on ensuring that the IMD
 
 ## Using User Data in Addons
 
+**The Addon SDK now [supports user data](./api/responses/manifest.md#user-data), this part of the docs will remain here as it is valid for use with the Express module.**
+
 This example does not use the Stremio Addon SDK, it uses Node.js and Express to serve replies.
 
 User data is passed in the Addon Repository URL, so instead of users installing addons from the normal manifest url (for example: `https://www.mydomain.com/manifest.json`), users will also need to add the data they want to pass to the addon in the URL (for example: `https://www.mydomain.com/c9y2kz0c26c3w4csaqne71eu4jqko7e1/manifest.json`, where `c9y2kz0c26c3w4csaqne71eu4jqko7e1` could be their API Authentication Token)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -382,23 +382,6 @@ The `/configure` web page should include a form with all required data, the form
 
 An "Install Addon" button should be available on the page that will use the `stremio://` protocol, for example, if your Addon Repository URL is `https://my.addon.com/some-user-data/manifest.json`, the "Install Addon" button should point to `stremio://my.addon.com/some-user-data/manifest.json`. (the `stremio://` protocol links will open or focus the Stremio app with a prompt to install the addon)
 
-At this point your addon should support settings for Desktop and Mobile devices, if you wish to also support TV devices you must follow the guide from the [Configuring Addons on TV Devices](#configuring-addons-on-tv-devices) section.
-
-
-## Configuring Addons on TV Devices
-
-This guide extends [Using User Data in Addons](#using-user-data-in-addons) and [Creating Addon Configuration Pages](#creating-addon-configuration-pages) with support for Addon Settings on TV devices.
-
-If your addon supports addon settings (`manifest.behaviorHints.configurable` is `true`) you might also want to support addon settings for TV devices. In order to do this, you will need to also set `manifest.behaviorHints.configurableTV` to `true` and the `/configure` web page of your addon must support passing data through the "Account Link" API.
-
-This is important because most TV devices do no support a browser of their own.
-
-Using the Account Link API:
-- the `/configure` path will be called with the `code` GET variable (example: `/configure?code=XXXX`)
-- the "Install Addon" button of your `/configure` page must handle passing the configured Addon Repository URL if the `code` GET variable is received; in order to do this you will need to make a POST request to `https://link.stremio.com/api/write?code=XXXX` with the Addon Repository URL (example post data: `{"manifestUrl":"https://my.addon.com/some-user-data/manifest.json"}`)
-- show a failed message to the user if you receive `{ "result": null, "error": { "code": XX, "message": "..." } }` as a reply from the API; this means that the code received is either invalid or has expired
-- show a success message to the user if you receive `{ "result": { "success": true }, "error": null }` as a reply from the API
-
 
 ## Using Deep Links in Addons
 

--- a/docs/api/requests/defineCatalogHandler.md
+++ b/docs/api/requests/defineCatalogHandler.md
@@ -28,6 +28,8 @@ The resolving object can also include the following cache related properties:
 
 ``extra`` - object that holds additional properties; defined below
 
+``config`` - object with user settings, see [Manifest - User Data](../responses/manifest.md#user-data)
+
 
 ## Extra Parameters
 

--- a/docs/api/requests/defineMetaHandler.md
+++ b/docs/api/requests/defineMetaHandler.md
@@ -25,6 +25,8 @@ The resolving object can also include the following cache related properties:
 
 ``id`` - string id of the meta item that is requested; these are set in the [Meta Preview Object](../responses/meta.md#meta-preview-object)
 
+``config`` - object with user settings, see [Manifest - User Data](../responses/manifest.md#user-data)
+
 
 ## Basic Example
 

--- a/docs/api/requests/defineResourceHandler.md
+++ b/docs/api/requests/defineResourceHandler.md
@@ -26,6 +26,8 @@ The resolving object can also include the following cache related properties:
 
 ``id`` - string id of the catalog that is requested; these are set in the [Manifest Object](../responses/manifest.md)
 
+``config`` - object with user settings, see [Manifest - User Data](../responses/manifest.md#user-data)
+
 
 ## Basic Example
 

--- a/docs/api/requests/defineStreamHandler.md
+++ b/docs/api/requests/defineStreamHandler.md
@@ -29,6 +29,7 @@ The resolving object can also include the following cache related properties:
 
 For IMDb series (provided by Cinemeta), the video ID is formed by joining the Meta ID, season and episode with a colon (e.g. `"tt0898266:9:17"`).
 
+``config`` - object with user settings, see [Manifest - User Data](../responses/manifest.md#user-data)
 
 ## Basic Example
 

--- a/docs/api/requests/defineSubtitlesHandler.md
+++ b/docs/api/requests/defineSubtitlesHandler.md
@@ -27,6 +27,8 @@ The resolving object can also include the following cache related properties:
 
 ``extra`` - object that holds additional properties; parameters defined below
 
+``config`` - object with user settings, see [Manifest - User Data](../responses/manifest.md#user-data)
+
 
 ## Extra Parameters
 

--- a/docs/api/responses/manifest.md
+++ b/docs/api/responses/manifest.md
@@ -94,6 +94,32 @@ If you're looking for the legacy way of setting extra properties (also called "s
 
 ``name`` - **required** - string, human readable name of the catalog
 
+## User data
+
+You can choose to accept user data for your addon, to do this you will need to first set `manifest.behaviorHints.configurable` to `true`, then set the `manifest.config` property.
+
+When setting the `manifest.config` property, the landing page will redirect to `/configure` where there will be an auto-generated configuration page.
+
+***TIP* - you can also set `manifest.behaviorHints.configurationRequired` to state that your addon does not work without user data**
+
+* ``config`` - _optional_ - array of [``Config objects``](#config-format), a list of settings that users can set for your addon
+
+### Config format
+
+``key`` - _required_ - string, a key that will identify the user chosen value
+
+``type`` - _required_ - string, can be "string", "number", "boolean" or "select"
+
+``default`` - _optional_ - string, the default value, for `type: "boolean"` this can be set to "checked" to default to enabled
+
+``title`` - _optional_ - string, the title of the setting
+
+``options`` - _optional_ - array, the list of (string) choices for `type: "select"`
+
+``required`` - _optional_ - boolean, if the value is required or not, only applies to the following types: "string", "number"
+
+***TIP* - if you require a more advanced configuration page, you can also [create this page yourself](../../advanced.md#using-user-data-in-addons) instead of using the Addon SDK.**
+
 ## Other metadata
 
 ``background`` - _optional_ - string, background image for the addon; URL to png/jpg, at least 1024x786 resolution
@@ -108,11 +134,11 @@ If you're looking for the legacy way of setting extra properties (also called "s
 
 - ``p2p`` - boolean, if the addon includes P2P content, such as BitTorrent, which may reveal the user's IP to other streaming parties; used to provide an adequate warning to the user
 
-- ``configurable`` - boolean, default is `false`, if the addon supports settings, will add a button next to "Install" in Stremio that will point to the `/configure` path on the addon's domain, for more information read [Using User Data](../../advanced.md#using-user-data-in-addons) and [Creating Addon Configuration Pages](../..//advanced.md#creating-addon-configuration-pages)
+- ``configurable`` - boolean, default is `false`, if the addon supports settings, will add a button next to "Install" in Stremio that will point to the `/configure` path on the addon's domain, for more information read [User Data](#user-data) (or if you are not using the Addon SDK, read: [Advanced User Data](../../advanced.md#using-user-data-in-addons) and [Creating Addon Configuration Pages](../..//advanced.md#creating-addon-configuration-pages))
 
 - ``configurableTV`` - boolean, default is `false`, if set to `true` the Stremio application on TV devices expects [Configuring Addons on TV Devices](../../advanced.md#configuring-addons-on-tv-devices) to be supported by your addon
 
-- ``configurationRequired`` - boolean, default is `false`, if set to `true` the "Install" button will not show for your addon in Stremio, instead a "Configure" button will show pointing to the `/configure` path on the addon's domain, for more information read [Using User Data](../../advanced.md#using-user-data-in-addons)
+- ``configurationRequired`` - boolean, default is `false`, if set to `true` the "Install" button will not show for your addon in Stremio, instead a "Configure" button will show pointing to the `/configure` path on the addon's domain, for more information read [User Data](#user-data) (or if you are not using the Addon SDK, read: [Advanced User Data](../../advanced.md#using-user-data-in-addons) and [Creating Addon Configuration Pages](../..//advanced.md#creating-addon-configuration-pages))
 
 
 ***TIP* - to implement sources where streams are geo-restricted, see [``Stream objects``](./stream.md) `geos`**

--- a/docs/api/responses/manifest.md
+++ b/docs/api/responses/manifest.md
@@ -116,7 +116,7 @@ When setting the `manifest.config` property, the landing page will redirect to `
 
 ``options`` - _optional_ - array, the list of (string) choices for `type: "select"`
 
-``required`` - _optional_ - boolean, if the value is required or not, only applies to the following types: "string", "number"
+``required`` - _optional_ - boolean, if the value is required or not, only applies to the following types: "string", "number" (default is `false`)
 
 ***TIP* - if you require a more advanced configuration page, you can also [create this page yourself](../../advanced.md#using-user-data-in-addons) instead of using the Addon SDK.**
 

--- a/docs/api/responses/manifest.md
+++ b/docs/api/responses/manifest.md
@@ -136,8 +136,6 @@ When setting the `manifest.config` property, the landing page will redirect to `
 
 - ``configurable`` - boolean, default is `false`, if the addon supports settings, will add a button next to "Install" in Stremio that will point to the `/configure` path on the addon's domain, for more information read [User Data](#user-data) (or if you are not using the Addon SDK, read: [Advanced User Data](../../advanced.md#using-user-data-in-addons) and [Creating Addon Configuration Pages](../..//advanced.md#creating-addon-configuration-pages))
 
-- ``configurableTV`` - boolean, default is `false`, if set to `true` the Stremio application on TV devices expects [Configuring Addons on TV Devices](../../advanced.md#configuring-addons-on-tv-devices) to be supported by your addon
-
 - ``configurationRequired`` - boolean, default is `false`, if set to `true` the "Install" button will not show for your addon in Stremio, instead a "Configure" button will show pointing to the `/configure` path on the addon's domain, for more information read [User Data](#user-data) (or if you are not using the Addon SDK, read: [Advanced User Data](../../advanced.md#using-user-data-in-addons) and [Creating Addon Configuration Pages](../..//advanced.md#creating-addon-configuration-pages))
 
 

--- a/docs/api/responses/manifest.md
+++ b/docs/api/responses/manifest.md
@@ -108,7 +108,7 @@ When setting the `manifest.config` property, the landing page will redirect to `
 
 ``key`` - _required_ - string, a key that will identify the user chosen value
 
-``type`` - _required_ - string, can be "string", "number", "boolean" or "select"
+``type`` - _required_ - string, can be "text", "number", "password", "checkbox" or "select"
 
 ``default`` - _optional_ - string, the default value, for `type: "boolean"` this can be set to "checked" to default to enabled
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -79,7 +79,7 @@ function AddonBuilder(manifest) {
 
 function AddonInterface(manifest, handlers) {
 	this.manifest = Object.freeze(Object.assign({}, manifest))
-	this.get = (resource, type, id, extra = {}) => {
+	this.get = (resource, type, id, extra = {}, config = {}) => {
 		const handler = handlers[resource]
 		if (!handler) {
 			return Promise.reject({
@@ -87,7 +87,7 @@ function AddonInterface(manifest, handlers) {
 				noHandler: true
 			})
 		}
-		return handler({ type, id, extra })
+		return handler({ type, id, extra, config })
 	}
 	return this
 }

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -23,7 +23,13 @@ function getRouter({ manifest , get }) {
 		res.end(manifestRespBuf)
 	}
 
-	const configPrefix = (manifest.config || []).length ? '/:config?' : ''
+	const hasConfig = (manifest.config || []).length
+
+	if (hasConfig && !(manifest.behaviorHints || {}).configurable) {
+		console.warn(`manifest.config is set but manifest.behaviorHints.configurable is disabled, the "Configure" button will not show in the Stremio apps`)
+	}
+
+	const configPrefix = hasConfig ? '/:config?' : ''
 
 	router.get(`${configPrefix}/manifest.json`, manifestHandler)
 

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -221,6 +221,7 @@ function landingTemplate(manifest) {
             `
          } else if (elem.type === 'boolean') {
             const isChecked = elem.default === 'checked' ? ' checked' : ''
+            const defaultValue = elem.default === 'checked' ? 'true' : 'false'
             options += `
                <div class="form-element">
                   <label for="${key}">
@@ -229,7 +230,7 @@ function landingTemplate(manifest) {
                </div>
                `
             script += `
-               config["${key}"] = false
+               config["${key}"] = ${defaultValue}
                document.getElementById("${key}").addEventListener('change', (event) => {
                   config["${key}"] = !!event.currentTarget.checked
                   installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -177,32 +177,18 @@ function landingTemplate(manifest) {
 
    if ((manifest.config || []).length) {
       let options = ''
-      script = `
-         const config = {}
-      `
       manifest.config.forEach(elem => {
          const key = elem.key
          if (elem.type === 'string') {
             const isRequired = elem.required ? ' required' : ''
-            const defaultValue = elem.default ? `"${elem.default}"` : 'false'
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
             options += `
                <div class="form-element">
                   <input type="text" id="${key}" name="${key}" placeholder="${elem.title}"${defaultHTML}${isRequired}/>
                </div>
                `
-            script += `
-               config["${key}"] = ${defaultValue}
-               const ${key}Handler = (event) => {
-                 config["${key}"] = event.target.value
-                 installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
-               }
-               document.getElementById("${key}").addEventListener('input', ${key}Handler);
-               document.getElementById("${key}").addEventListener('propertychange', ${key}Handler);
-            `
          } else if (elem.type === 'number') {
             const isRequired = elem.required ? ' required' : ''
-            const defaultValue = elem.default ? `"${elem.default}"` : 'false'
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
             options += `
                <div class="form-element">
@@ -210,18 +196,8 @@ function landingTemplate(manifest) {
                   <input type="number" id="${key}" name="${key}" placeholder="${elem.title}"${defaultHTML}${isRequired}/>
                </div>
                `
-            script += `
-               config["${key}"] = ${defaultValue}
-               const ${key}Handler = (event) => {
-                 config["${key}"] = event.target.value
-                 installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
-               }
-               document.getElementById("${key}").addEventListener('input', ${key}Handler);
-               document.getElementById("${key}").addEventListener('propertychange', ${key}Handler);
-            `
          } else if (elem.type === 'boolean') {
             const isChecked = elem.default === 'checked' ? ' checked' : ''
-            const defaultValue = elem.default === 'checked' ? 'true' : 'false'
             options += `
                <div class="form-element">
                   <label for="${key}">
@@ -229,15 +205,8 @@ function landingTemplate(manifest) {
                   </label>
                </div>
                `
-            script += `
-               config["${key}"] = ${defaultValue}
-               document.getElementById("${key}").addEventListener('change', (event) => {
-                  config["${key}"] = !!event.currentTarget.checked
-                  installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
-               })
-            `
          } else if (elem.type === 'select') {
-            const defaultValue = '"' + (elem.default || (elem.options || [])[0]) + '"'
+            const defaultValue = elem.default || (elem.options || [])[0]
             options += `<div class="form-element">
                <select id="${key}" name="${key}">
                `
@@ -250,27 +219,26 @@ function landingTemplate(manifest) {
                <label for="${key}" class="label-to-left">${elem.title}</label>
                </div>
                `
-            script += `
-               config["${key}"] = ${defaultValue}
-               document.getElementById("${key}").addEventListener("change", () => {
-                  config["${key}"] = this.value
-                  installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
-               })
-            `
          }
       })
       if (options.length) {
          formHTML = `
-            <form class="pure-form" id="main-form">
+            <form class="pure-form" id="mainForm">
                ${options}
             </form>
 
             <div class="separator"></div>
             `
          script += `
-            document.getElementById('installLink').onclick = () => {
-               return document.getElementById("main-form").reportValidity()
+            installLink.onclick = () => {
+               return mainForm.reportValidity()
             }
+            const updateLink = () => {
+               const config = JSON.stringify(Object.fromEntries(new FormData(mainForm).entries()))
+               installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
+            }
+            mainForm.onchange = updateLink
+            updateLink()
          `
       }
    }

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -179,24 +179,17 @@ function landingTemplate(manifest) {
       let options = ''
       manifest.config.forEach(elem => {
          const key = elem.key
-         if (elem.type === 'string') {
+         if (['text', 'number', 'password'].includes(elem.type)) {
             const isRequired = elem.required ? ' required' : ''
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
-            options += `
-               <div class="form-element">
-                  <input type="text" id="${key}" name="${key}" placeholder="${elem.title}"${defaultHTML}${isRequired}/>
-               </div>
-               `
-         } else if (elem.type === 'number') {
-            const isRequired = elem.required ? ' required' : ''
-            const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
+            const inputType = elem.type
             options += `
                <div class="form-element">
                   <div class="label-to-top">${elem.title}</div>
-                  <input type="number" id="${key}" name="${key}" placeholder="${elem.title}"${defaultHTML}${isRequired}/>
+                  <input type="${inputType}" id="${key}" name="${key}"${defaultHTML}${isRequired}/>
                </div>
                `
-         } else if (elem.type === 'boolean') {
+         } else if (elem.type === 'checkbox') {
             const isChecked = elem.default === 'checked' ? ' checked' : ''
             options += `
                <div class="form-element">

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -180,13 +180,10 @@ function landingTemplate(manifest) {
       script = `
          const config = {}
       `
-      const requiredOptions = []
       manifest.config.forEach(elem => {
          const key = elem.key
          if (elem.type === 'string') {
             const isRequired = elem.required ? ' required' : ''
-            if (isRequired)
-               requiredOptions.push(key)
             const defaultValue = elem.default ? `"${elem.default}"` : 'false'
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
             options += `
@@ -205,8 +202,6 @@ function landingTemplate(manifest) {
             `
          } else if (elem.type === 'number') {
             const isRequired = elem.required ? ' required' : ''
-            if (isRequired)
-               requiredOptions.push(key)
             const defaultValue = elem.default ? `"${elem.default}"` : 'false'
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
             options += `
@@ -265,25 +260,17 @@ function landingTemplate(manifest) {
       })
       if (options.length) {
          formHTML = `
-            <form class="pure-form">
+            <form class="pure-form" id="main-form">
                ${options}
             </form>
 
             <div class="separator"></div>
             `
-         if (requiredOptions.length) {
-            script += `
-               const requiredOptions = ${JSON.stringify(requiredOptions)}
-               document.getElementById('installLink').onclick = () => {
-                  const notSet = (requiredOptions || []).find(el => !config[el])
-                  if (notSet) {
-                     alert(notSet + ' is required but not set')
-                     return false
-                  }
-                  return true
-               }
-            `
-         }
+         script += `
+            document.getElementById('installLink').onclick = () => {
+               return document.getElementById("main-form").reportValidity()
+            }
+         `
       }
    }
 

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -176,11 +176,14 @@ function landingTemplate(manifest) {
       script = `
          const config = {}
       `
+      const requiredOptions = []
       manifest.config.forEach(elem => {
          const key = elem.key
          if (['string', 'number'].includes(elem.type)) {
             const isNumber = elem.type == 'number' ? ' pattern="-?[0-9]*(\\.[0-9]+)?"' : ''
             const isRequired = elem.required ? ' required' : ''
+            if (isRequired)
+               requiredOptions.push(key)
             const defaultValue = elem.default ? `"${elem.default}"` : 'false'
             const defaultHTML = elem.default ? ` value="${elem.default}"` : ''
             options += `
@@ -244,6 +247,19 @@ function landingTemplate(manifest) {
 
             <div class="separator"></div>
             `
+         if (requiredOptions.length) {
+            script += `
+               const requiredOptions = ${JSON.stringify(requiredOptions)}
+               document.getElementById('installLink').onclick = () => {
+                  const notSet = requiredOptions.find(el => !config[el])
+                  if (notSet) {
+                     alert(notSet + ' is required but not set')
+                     return false
+                  }
+                  return true
+               }
+            `
+         }
       }
    }
 

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -234,11 +234,10 @@ function landingTemplate(manifest) {
                return mainForm.reportValidity()
             }
             const updateLink = () => {
-               const config = JSON.stringify(Object.fromEntries(new FormData(mainForm).entries()))
+               const config = Object.fromEntries(new FormData(mainForm).entries())
                installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
             }
             mainForm.onchange = updateLink
-            updateLink()
          `
       }
    }
@@ -284,8 +283,8 @@ function landingTemplate(manifest) {
       <script>
          ${script}
 
-         if (config && Object.keys(config).length)
-            installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
+         if (typeof updateLink === 'function')
+            updateLink()
          else
             installLink.href = 'stremio://' + window.location.host + '/manifest.json'
       </script>

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -8,19 +8,23 @@ html {
    margin: 0;
    padding: 0;
    width: 100%;
-   height: 100%
+   min-height: 100%;
+}
+
+body {
+   padding: 2vh;
 }
 
 html {
    background-size: auto 100%;
    background-size: cover;
    background-position: center center;
-   background-repeat: no-repeat
+   background-repeat: no-repeat;
+   box-shadow: inset 0 0 0 2000px rgb(0 0 0 / 60%);
 }
 
 body {
    display: flex;
-   background: rgba(0, 0, 0, 0.60);
    font-family: 'Open Sans', Arial, sans-serif;
    color: white;
 }

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -13,6 +13,7 @@ html {
 
 body {
    padding: 2vh;
+   font-size: 2.2vh;
 }
 
 html {
@@ -154,9 +155,12 @@ button:active {
    margin-bottom: 2vh;
 }
 
-.label-to-left {
-   float: left;
-   margin-right: 2vh !important;
+.label-to-right {
+   margin-left: 1vh !important;
+}
+
+.full-width {
+   width: 100%;
 }
 `
 
@@ -186,7 +190,7 @@ function landingTemplate(manifest) {
             options += `
                <div class="form-element">
                   <div class="label-to-top">${elem.title}</div>
-                  <input type="${inputType}" id="${key}" name="${key}"${defaultHTML}${isRequired}/>
+                  <input type="${inputType}" id="${key}" name="${key}" class="full-width"${defaultHTML}${isRequired}/>
                </div>
                `
          } else if (elem.type === 'checkbox') {
@@ -194,14 +198,15 @@ function landingTemplate(manifest) {
             options += `
                <div class="form-element">
                   <label for="${key}">
-                     <input type="checkbox" id="${key}" name="${key}"${isChecked}> <span class="label-to-left">${elem.title}</span>
+                     <input type="checkbox" id="${key}" name="${key}"${isChecked}> <span class="label-to-right">${elem.title}</span>
                   </label>
                </div>
                `
          } else if (elem.type === 'select') {
             const defaultValue = elem.default || (elem.options || [])[0]
             options += `<div class="form-element">
-               <select id="${key}" name="${key}">
+               <div class="label-to-top">${elem.title}</div>
+               <select id="${key}" name="${key}" class="full-width">
                `
             const selections = elem.options || []
             selections.forEach(el => {
@@ -209,7 +214,6 @@ function landingTemplate(manifest) {
                options += `<option value="${el}"${isSelected}>${el}</option>`
             })
             options += `</select>
-               <label for="${key}" class="label-to-left">${elem.title}</label>
                </div>
                `
          }

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -121,13 +121,14 @@ button:active {
 
 .name {
    line-height: 5vh;
+   margin: 0;
 }
 
 .version {
-   position: absolute;
+   position: relative;
    line-height: 5vh;
-   margin-left: 1vh;
    opacity: 0.8;
+   margin-bottom: 2vh;
 }
 
 .contact {
@@ -258,7 +259,7 @@ function landingTemplate(manifest) {
             <img src="${logo}">
          </div>
          <h1 class="name">${manifest.name}</h1>
-         <h2 class="version">${manifest.version || '0.0.0'}</h2>
+         <h2 class="version">v${manifest.version || '0.0.0'}</h2>
          <h2 class="description">${manifest.description || ''}</h2>
 
          <div class="separator"></div>

--- a/src/landingTemplate.js
+++ b/src/landingTemplate.js
@@ -234,7 +234,7 @@ function landingTemplate(manifest) {
                return mainForm.reportValidity()
             }
             const updateLink = () => {
-               const config = Object.fromEntries(new FormData(mainForm).entries())
+               const config = Object.fromEntries(new FormData(mainForm))
                installLink.href = 'stremio://' + window.location.host + '/' + encodeURIComponent(JSON.stringify(config)) + '/manifest.json'
             }
             mainForm.onchange = updateLink

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -30,12 +30,24 @@ function serveHTTP(addonInterface, opts = {}) {
 		app.use(opts.static, express.static(location))
 	}
 
+	const hasConfig = !!(addonInterface.manifest.config || []).length
+
 	// landing page
 	const landingHTML = landingTemplate(addonInterface.manifest)
 	app.get('/', (_, res) => {
-		res.setHeader('content-type', 'text/html')
-		res.end(landingHTML)
+		if (hasConfig) {
+			res.redirect('/configure')
+		} else {
+			res.setHeader('content-type', 'text/html')
+			res.end(landingHTML)
+		}
 	})
+
+	if (hasConfig)
+		app.get('/configure', (_, res) => {
+			res.setHeader('content-type', 'text/html')
+			res.end(landingHTML)
+		})
 
 	const server = app.listen(opts.port)
 	return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Implements addon user settings in the sdk, the docs are not ready yet.

manifest:
```javascript
{
  behaviorHints: {
    configurable: true
  },
  config: [
        {
            key: "username",
            title: "Username",
            type: "string",
            required: true
        },
        {
            key: "check",
            title: "Checkbox",
            type: "boolean"
        },
        {
            key: "style",
            title: "Style",
            type: "select",
            options: ["Catalog", "Filters", "Channel"]
        }
    ]
}
```

When using any handler:
```javascript
builder.defineCatalogHandler((args) => {
    console.log(args.config);
    // { username: "jaruba", check: false, style: 'Catalog' }
})
```