### PR TITLE
fixed router to have the right order of parameters

### DIFF
--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -43,10 +43,10 @@ function getRouter({ manifest , get }) {
 	manifest.resources.forEach((r) => handlersInManifest.push(r.name || r))
 	
 	// converting the resources array to a regular expression
-	const ResourcesRegex = handlersInManifest.toString().replaceAll(',','|')
+	const ResourcesRegex = handlersInManifest && handlersInManifest.length ? "(" + handlersInManifest.join('|') + ")" : "" ;
 
 	// Handle all resources
-	router.get(`${configPrefix}/:resource(${ResourcesRegex})/:type/:id/:extra?.json`, function(req, res, next) {
+	router.get(`${configPrefix}/:resource${ResourcesRegex}/:type/:id/:extra?.json`, function(req, res, next) {
 		const { resource, type, id } = req.params
 		let { config } = req.params
 		// we get `extra` from `req.url` because `req.params.extra` decodes the characters

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -43,7 +43,7 @@ function getRouter({ manifest , get }) {
 	manifest.resources.forEach((r) => handlersInManifest.push(r.name || r))
 	
 	// converting the resources array to a regular expression
-	const ResourcesRegex = handlersInManifest && handlersInManifest.length ? "(" + handlersInManifest.join('|') + ")" : "" ;
+	const ResourcesRegex = handlersInManifest && handlersInManifest.length ? '(' + handlersInManifest.join('|') + ')' : '' 
 
 	// Handle all resources
 	router.get(`${configPrefix}/:resource${ResourcesRegex}/:type/:id/:extra?.json`, function(req, res, next) {

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -34,7 +34,7 @@ function getRouter({ manifest , get }) {
 	router.get(`${configPrefix}/manifest.json`, manifestHandler)
 
 	// Handle all resources
-	router.get(`${configPrefix}/:resource/:type/:id/:extra?.json`, function(req, res, next) {
+	router.get(`${configPrefix}/:resource(stream|meta|catalog|subtitles)/:type/:id/:extra?.json`, function(req, res, next) {
 		const { resource, type, id } = req.params
 		let { config } = req.params
 		// we get `extra` from `req.url` because `req.params.extra` decodes the characters

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -32,8 +32,8 @@ function getRouter({ manifest , get }) {
 	}
 
 	const configPrefix = hasConfig ? '/:config?' : ''
-	// having config prifix always set to '/:config?' won't resault in a problem for non configurable addons 
-	// since now the order is restricted by resources 
+	// having config prifix always set to '/:config?' won't resault in a problem for non configurable addons,
+	// since now the order is restricted by resources.
 
 	router.get(`${configPrefix}/manifest.json`, manifestHandler)
 

--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -32,11 +32,21 @@ function getRouter({ manifest , get }) {
 	}
 
 	const configPrefix = hasConfig ? '/:config?' : ''
+	// having config prifix always set to '/:config?' won't resault in a problem for non configurable addons 
+	// since now the order is restricted by resources 
 
 	router.get(`${configPrefix}/manifest.json`, manifestHandler)
 
+	// using the same methode used in builder.js to extract resources from manifest
+	const handlersInManifest = []
+	if (manifest.catalogs.length > 0) handlersInManifest.push('catalog')
+	manifest.resources.forEach((r) => handlersInManifest.push(r.name || r))
+	
+	// converting the resources array to a regular expression
+	const ResourcesRegex = handlersInManifest.toString().replaceAll(',','|')
+
 	// Handle all resources
-	router.get(`${configPrefix}/:resource(stream|meta|catalog|subtitles)/:type/:id/:extra?.json`, function(req, res, next) {
+	router.get(`${configPrefix}/:resource(${ResourcesRegex})/:type/:id/:extra?.json`, function(req, res, next) {
 		const { resource, type, id } = req.params
 		let { config } = req.params
 		// we get `extra` from `req.url` because `req.params.extra` decodes the characters


### PR DESCRIPTION
using manifest.resources as constraint for req.params.resource to avoid conflict in the order of the request parameters.
