### PR TITLE
Update cinemeta addon URL

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -298,7 +298,7 @@ var needle = require('needle')
 var itemType = 'movie'
 var itemImdbId = 'tt1254207'
 
-needle.get('https://v3-cinemeta.strem.io/meta/' + itemType + '/' + itemImdbId + '.json', function(err, resp, body) {
+needle.get('https://cinemeta-live.strem.io/meta/' + itemType + '/' + itemImdbId + '.json', function(err, resp, body) {
 
   if (body && body.meta) {
 


### PR DESCRIPTION
Looks like the cinemeta addon URL has changed. Some HTTP clients don't handle redirects by default, so the docs should be updated to reflect this change.