### PR TITLE
refactor(): Move landing and config setup page to router

### DIFF
--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -1,6 +1,7 @@
 const Router = require('router')
 const qs = require('querystring')
 const cors = require('cors')
+const landingTemplate = require('./landingTemplate')
 
 const warned = {}
 
@@ -33,8 +34,28 @@ function getRouter({ manifest , get }) {
 		console.warn('manifest.config is set but manifest.behaviorHints.configurable is disabled, the "Configure" button will not show in the Stremio apps')
 	}
 
+	// landing page
+	const landingHTML = landingTemplate(manifest)
+	
+	router.get('/', (_, res) => {
+		if (hasConfig) {
+			res.redirect('/configure')
+		} else {
+			res.setHeader('content-type', 'text/html')
+			res.end(landingHTML)
+		}
+	})
+
+	if (hasConfig) {
+		router.get('/configure', (_, res) => {
+			res.setHeader('content-type', 'text/html')
+			res.end(landingHTML)
+		})  
+	}
+
+
 	const configPrefix = hasConfig ? '/:config?' : ''
-	// having config prifix always set to '/:config?' won't resault in a problem for non configurable addons,
+	// having config prefix always set to '/:config?' won't result in a problem for non-configurable addons,
 	// since now the order is restricted by resources.
 
 	router.get(`${configPrefix}/manifest.json`, manifestHandler)

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ module.exports = {
 	addonBuilder: require('./builder'),
 	serveHTTP: require('./serveHTTP'),
 	getRouter: require('./getRouter'),
+	landingTemplate: require('./landingTemplate'),
 	publishToCentral: require('./publishToCentral'),
 }

--- a/src/serveHTTP.js
+++ b/src/serveHTTP.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const fs = require('fs')
 const path = require('path')
-const landingTemplate = require('./landingTemplate')
 const getRouter = require('./getRouter')
 const opn = require('opn')
 
@@ -29,25 +28,6 @@ function serveHTTP(addonInterface, opts = {}) {
 		if (!fs.existsSync(location)) throw new Error('directory to serve does not exist')
 		app.use(opts.static, express.static(location))
 	}
-
-	const hasConfig = !!(addonInterface.manifest.config || []).length
-
-	// landing page
-	const landingHTML = landingTemplate(addonInterface.manifest)
-	app.get('/', (_, res) => {
-		if (hasConfig) {
-			res.redirect('/configure')
-		} else {
-			res.setHeader('content-type', 'text/html')
-			res.end(landingHTML)
-		}
-	})
-
-	if (hasConfig)
-		app.get('/configure', (_, res) => {
-			res.setHeader('content-type', 'text/html')
-			res.end(landingHTML)
-		})
 
 	const server = app.listen(opts.port)
 	return new Promise(function(resolve, reject) {


### PR DESCRIPTION
This PR moves the landing page and/or config page to the router, so it can be reused when used with your own Express/router instance