### PR TITLE
Fix config prefix logic for configurable addons

### DIFF
--- a/src/getRouter.js
+++ b/src/getRouter.js
@@ -27,13 +27,14 @@ function getRouter({ manifest , get }) {
 		res.end(manifestRespBuf)
 	}
 
+	const hasConfigBehaviorHint = (manifest.behaviorHints || {}).configurable
 	const hasConfig = (manifest.config || []).length
 
-	if (hasConfig && !(manifest.behaviorHints || {}).configurable) {
+	if (hasConfig && !hasConfigBehaviorHint) {
 		console.warn('manifest.config is set but manifest.behaviorHints.configurable is disabled, the "Configure" button will not show in the Stremio apps')
 	}
 
-	const configPrefix = hasConfig ? '/:config?' : ''
+	const configPrefix = hasConfig || hasConfigBehaviorHint ? '/:config?' : ''
 	// having config prifix always set to '/:config?' won't resault in a problem for non configurable addons,
 	// since now the order is restricted by resources.
 


### PR DESCRIPTION
Adds the config prefix to addons that don't have a `config` object defined in their `manifest.json`, but do have `manifest.behaviorHints.configurable` set to `true`. This is the case for addons with a custom configuration page.

Not 100% sure if it makes sense to support this in the official SDK. It's something I'm adding to the unofficial community SDK at https://github.com/Stremio-Community/stremio-addon-sdk/pull/27 and figured to create this PR to upstream the changes just in case it's useful.