### PR TITLE
feat: add skips resource type for content filtering and segment skipping

### DIFF
--- a/docs/api/requests/defineSkipsHandler.md
+++ b/docs/api/requests/defineSkipsHandler.md
@@ -1,0 +1,99 @@
+# defineSkipsHandler
+
+Handles skip segment requests for content filtering, intro skipping, ad skipping, etc.
+
+## Arguments
+
+`args` - Object containing:
+
+- `type` - Content type (`movie`, `series`)
+- `id` - IMDB ID (e.g., `tt1234567` for movies, `tt1234567:1:1` for series episodes)
+- `extra` - Additional parameters
+- `config` - User configuration from the addon
+
+## Returns
+
+A Promise resolving to an object containing:
+
+```javascript
+{
+  skips: [
+    {
+      id: "skip-1",           // Unique identifier for this skip segment
+      startMs: 3600000,       // Start time in milliseconds
+      endMs: 3660000,         // End time in milliseconds  
+      category: "violence",   // Category: nudity, sex, violence, language, drugs, fear, intro, outro, recap, ad
+      severity: "high",       // Severity level: low, medium, high
+      description: "Fight scene", // Optional human-readable description
+      action: "skip"          // Optional: "skip" (auto-skip) or "warn" (show button)
+    }
+  ]
+}
+```
+
+## Example
+
+```javascript
+const { addonBuilder } = require('stremio-addon-sdk')
+
+const builder = new addonBuilder({
+  id: 'org.example.myskipaddon',
+  version: '1.0.0',
+  name: 'My Skip Addon',
+  resources: ['skips'],
+  types: ['movie', 'series'],
+  idPrefixes: ['tt']
+})
+
+builder.defineSkipsHandler(async ({ type, id, config }) => {
+  // Fetch skip data from your database
+  const skipData = await getSkipsFromDatabase(id)
+  
+  return {
+    skips: skipData.map(skip => ({
+      id: skip.id,
+      startMs: skip.startMs,
+      endMs: skip.endMs,
+      category: skip.category,
+      severity: skip.severity,
+      description: skip.description
+    }))
+  }
+})
+```
+
+## Use Cases
+
+- **Content filtering** - Skip nudity, violence, language (e.g., CleanStream, VidAngel-style)
+- **Intro/outro skipping** - Like Netflix's "Skip Intro" button
+- **Ad skipping** - For ad-supported content
+- **Recap skipping** - Skip "Previously on..." segments
+- **SponsorBlock-style** - Community-driven skip timestamps
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| `nudity` | Nudity, bare skin |
+| `sex` | Sexual content, intimacy |
+| `violence` | Fighting, blood, gore |
+| `language` | Profanity, slurs |
+| `drugs` | Drug/alcohol use |
+| `fear` | Scary scenes, jumpscares |
+| `intro` | Opening credits/intro sequence |
+| `outro` | End credits |
+| `recap` | "Previously on..." segments |
+| `ad` | Advertisements, promotions |
+
+## Severity Levels
+
+| Level | Description |
+|-------|-------------|
+| `low` | Mild content |
+| `medium` | Moderate content |
+| `high` | Intense/explicit content |
+
+## Related
+
+- [Feature Request #1608](https://github.com/Stremio/stremio-features/issues/1608) - Skip Segments API proposal
+- [CleanStream](https://cleanstream.elfhosted.com) - Reference implementation with 376+ movies

--- a/docs/api/responses/skips.md
+++ b/docs/api/responses/skips.md
@@ -1,0 +1,115 @@
+# Skips Response
+
+The skips response contains an array of skip segments for a given content item.
+
+## Format
+
+```javascript
+{
+  skips: [
+    {
+      id: String,          // Required: Unique identifier
+      startMs: Number,     // Required: Start time in milliseconds
+      endMs: Number,       // Required: End time in milliseconds
+      category: String,    // Required: Category of content to skip
+      severity: String,    // Optional: Severity level (low/medium/high)
+      description: String, // Optional: Human-readable description
+      action: String       // Optional: "skip" (auto) or "warn" (button)
+    }
+  ]
+}
+```
+
+## Fields
+
+### id (required)
+Unique identifier for the skip segment. Used for tracking, voting, and deduplication.
+
+### startMs (required)
+Start time in milliseconds from the beginning of the video.
+
+### endMs (required)
+End time in milliseconds. Must be greater than `startMs`.
+
+### category (required)
+Type of content being skipped. Valid values:
+
+| Category | Description |
+|----------|-------------|
+| `nudity` | Nudity, bare skin |
+| `sex` | Sexual content, intimacy |
+| `violence` | Fighting, blood, gore |
+| `language` | Profanity, slurs |
+| `drugs` | Drug/alcohol use |
+| `fear` | Scary scenes, jumpscares |
+| `intro` | Opening credits/intro |
+| `outro` | End credits |
+| `recap` | "Previously on..." |
+| `ad` | Advertisements |
+
+### severity (optional)
+Intensity level. Allows users to filter by severity.
+
+| Level | Description |
+|-------|-------------|
+| `low` | Mild |
+| `medium` | Moderate |
+| `high` | Intense/explicit |
+
+### description (optional)
+Human-readable description shown to the user.
+
+Example: `"Fight scene in lobby"`, `"Brief nudity"`, `"Opening credits"`
+
+### action (optional)
+How the player should handle the skip. Default is `"skip"`.
+
+| Action | Behavior |
+|--------|----------|
+| `skip` | Auto-skip when enabled |
+| `warn` | Show "Skip" button, don't auto-skip |
+
+## Example Response
+
+```javascript
+{
+  skips: [
+    {
+      id: "cs-tt0133093-1",
+      startMs: 1800000,
+      endMs: 1860000,
+      category: "violence",
+      severity: "high",
+      description: "Lobby shootout",
+      action: "skip"
+    },
+    {
+      id: "cs-tt0133093-2", 
+      startMs: 3600000,
+      endMs: 3720000,
+      category: "nudity",
+      severity: "medium",
+      description: "Brief nudity",
+      action: "skip"
+    },
+    {
+      id: "intro-tt0133093",
+      startMs: 0,
+      endMs: 45000,
+      category: "intro",
+      description: "Opening credits",
+      action: "warn"
+    }
+  ]
+}
+```
+
+## Empty Response
+
+When no skips are available:
+
+```javascript
+{
+  skips: []
+}
+```

--- a/src/builder.js
+++ b/src/builder.js
@@ -67,6 +67,7 @@ function AddonBuilder(manifest) {
 	this.defineMetaHandler = this.defineResourceHandler.bind(this, 'meta')
 	this.defineCatalogHandler = this.defineResourceHandler.bind(this, 'catalog')
 	this.defineSubtitlesHandler = this.defineResourceHandler.bind(this, 'subtitles')
+	this.defineSkipsHandler = this.defineResourceHandler.bind(this, 'skips')
 
 	// build into an interface
 	this.getInterface = function() {


### PR DESCRIPTION
## Summary

Adds `defineSkipsHandler()` for addons to provide skip segments, enabling content filtering, intro/outro skipping, and more.

## Changes

- Added `defineSkipsHandler` in `src/builder.js`
- Added documentation in `docs/api/requests/defineSkipsHandler.md`
- Added response format in `docs/api/responses/skips.md`

## Use Cases

- **Content filtering** - Skip nudity, violence, language (CleanStream, VidAngel-style)
- **Intro/outro skipping** - Like Netflix's "Skip Intro"
- **Ad skipping** - For ad-supported content
- **SponsorBlock-style** - Community-driven timestamps

## Related

- Feature Request: Stremio/stremio-features#1608
- Working implementation: [CleanStream](https://cleanstream.elfhosted.com) - 376+ movies ready

## Note

This PR adds the SDK support. Player-side implementation would be needed to complete the feature.