### PR TITLE
Update content and stream docs to reflect stremio-core

### DIFF
--- a/docs/api/responses/content.types.md
+++ b/docs/api/responses/content.types.md
@@ -1,10 +1,11 @@
 ## Content types
 
-**Stremio supports the following content types as of Apr 2016:**
+**Stremio supports the following content types as of Jan 2025:**
 
-* ``movie`` - movie type - has metadata like name, genre, description, director, actors, images, etc. 
-* ``series`` - series type - has all the metadata a movie has, plus an array of episodes
-* ``channel`` - channel type - created to cover YouTube channels; has name, description and an array of uploaded videos
-* ``tv`` - tv type - has name, description, genre; streams for ``tv`` should be live (without duration)
+* `movie` - movie type - has metadata like name, genre, description, director, actors, images, etc.
+* `series` - series type - has all the metadata a movie has, plus an array of episodes
+* `channel` - channel type - created to cover YouTube channels; has name, description and an array of uploaded videos
+* `tv` - tv type - has name, description, genre; streams for `tv` should be live (without duration)
+* `other` - other type - for anything else
 
 **If you think Stremio should add another content type, feel free to open an issue on this repository.**

--- a/docs/api/responses/meta.md
+++ b/docs/api/responses/meta.md
@@ -2,140 +2,254 @@
 
 Used as a response for [`defineMetaHandler`](../requests/defineMetaHandler.md)
 
-``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your addon, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
+* `id` - **required** - string, universal identifier; may include a [prefix](./manifest.md##filtering-properties) unique to your addon
 
-``type`` - **required** - string, type of the content; e.g. `movie`, `series`, `channel`, `tv` (see [Content Types](./content.types.md))
+* `type` - **required** - string, type of content; must be `movie`, `series`, `channel`, `tv`, or `other`. See [Content Types](./content.types.md) for more information
 
-``name`` - **required** - string, name of the content
+* `name` - **required** - string, name of the content
 
-``genres`` - _optional_  - array of strings, genre/categories of the content; e.g. ``["Thriller", "Horror"]`` (warning: this will soon be deprecated in favor of ``links``)
+* `poster` - *optional* - string, URL to image (recommended max file size of 50kb)
 
-``poster`` - _optional_ - string, URL to png of poster; accepted aspect ratios: 1:0.675 (IMDb poster type) or 1:1 (square) ; you can use any resolution, as long as the file size is below 100kb; below 50kb is recommended
+* `background` - *optional* - string, URL to image; displayed as the background on the Stremio detail page (recommended max file size of 500kb)
 
-``posterShape`` - _optional_ - string, can be `square` (1:1 aspect) or `poster` (1:0.675) or `landscape` (1:1.77). If you don't pass this, `poster` is assumed
+* `logo` - *optional* - string, URL to image; displayed as the logo on the Stremio detail page (PNG format recommended)
 
-``background`` - _optional_ - string, the background shown on the stremio detail page ; heavily encouraged if you want your content to look good; URL to PNG, max file size 500kb
+* `description` - *optional* - string, a few sentences describing the content
 
-``logo`` - _optional_ - string, the logo shown on the stremio detail page ; encouraged if you want your content to look good; URL to PNG
+* `releaseInfo` - *optional* - string, the release year of the content; for `series` or `channel` content, use the start and end years split by a hyphen (e.g., `"2000-2014"`). If still running, use a format like `"2000-"`
 
-``description`` - _optional_ - string, a few sentences describing your content
+* `runtime` - *optional* - string, human-readable expected runtime (e.g., `"120 min"`)
 
-``releaseInfo`` - _optional_ - string, year the content came out ; if it's ``series`` or ``channel``, use a start and end years split by a tide - e.g. ``"2000-2014"``. If it's still running, use a format like ``"2000-"``
+* `released` - *optional* - string (ISO 8601), initial release date; for movies, this is the cinema debut
 
-``director``, ``cast`` - _optional_  - directors and cast, both arrays of names (string) (warning: this will soon be deprecated in favor of ``links``)
+* `posterShape` - *optional* - string, aspect ratio of the poster; must be `square` (1:1), `poster` (1:0.675), or `landscape` (1:1.77). Defaults to `poster` if omitted
 
-``imdbRating`` -  _optional_ - string, IMDb rating, a number from 0.0 to 10.0 ; use if applicable
+* `links` - *optional* - array of [Link objects](#link-object), used to link to internal Stremio pages (e.g., actor, genre, or director links)
 
-``released`` - _optional_ - string, ISO 8601, initial release date; for movies, this is the cinema debut, e.g. "2010-12-06T05:00:00.000Z"
+* `trailerStreams` - *optional* - array of [Stream objects](./stream.md), contains trailers for the content
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip` (warning: this will soon be deprecated in favor of `meta.trailers` being an array of [``Stream Objects``](./stream.md))
+* `videos` - *optional* - array of [Video objects](#video-object), used for `channel` and `series`. If omitted, Stremio assumes a single video with an ID equal to the meta `id`
 
-``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
+* `behaviorHints` - object with behavior configuration, contains the following properties:
 
-``videos`` - _optional_ - array of [``Video objects``](#video-object), used for ``channel`` and ``series``; if you do not provide this (e.g. for ``movie``), Stremio assumes this meta item has one video, and it's ID is equal to the meta item `id`
+  * `defaultVideoId` - *optional* - string, the ID of a [Video Object](#video-object); set this to open the Detail page directly to that video's streams
 
-``runtime`` - _optional_ - string, human-readable expected runtime - e.g. "120m"
+  * `featuredVideoId` - *optional* - string, the ID of a [Video Object](#video-object); unused as of Jan 2026
 
-``language`` - _optional_ - string, spoken language
+  * `hasScheduledVideos` - *optional* - boolean, indicates whether the content videos scheduled to air in the future
 
-``country`` - _optional_ - string, official country of origin
+#### Legacy Properties
 
-``awards`` - _optional_ - string, human-readable that describes all the significant awards
+These properties are deprecated and new addons should not use them, but may still work for the time being.
 
-``website`` - _optional_ - string, URL to official website
+* `imdbRating` - *optional* - string, IMDb rating, a number from 0.0 to 10.0
+  > **Deprecated**: Add a [Link object](#link-object) to `links` instead (see [examples above](#examples))
 
-``behaviorHints`` - _all are optional_ - object, supports the properties:
+* `genres` - *optional* - array of strings, genre/categories of the content (e.g. `["Thriller", "Horror"]`)
+  > **Deprecated**: Add [Link objects](#link-object) to `links` instead
 
-- ``defaultVideoId`` - string, set to a [``Video Object``](#video-object) id in order to open the Detail page directly to that video's streams
+* `trailers` - *optional* - array of objects containing `{ source: string, type: string }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip`
+  > **Deprecated**: Add [Stream objects](./stream.md) to `trailerStreams` instead
 
+### Link Object
 
-#### Meta Link object
+* `name` - **required** - string, human readable name for the link
 
-``name`` - **required** - string, human readable name for the link
+* `category` - **required** - string, any unique category name; links are grouped based on their category
+  > **Recommended categories**: `cast`, `director`, `writer`, `genre`
+  >
+  > **Unique categories** (can only be used once): `imdb`, `share`\
+  > See [examples](#examples) for how to use these
 
-``category`` - **required** - string, any unique category name, links are grouped based on their category, some recommended categories are: `actor`, `director`, `writer`, while the following categories are reserved and should not be used: `imdb`, `share`, `similar`
+* `url` - **required** - string, an external URL or [Meta Link](./meta.links.md)
 
-``url`` - **required** - string, an external URL or [``Meta Link``](./meta.links.md)
+### Video Object
 
+An object representing individual videos within series or channels.
 
-#### Video object
+* `id` - **required** - string, ID of the video
 
-``id`` - **required** - string, ID of the video
+* `title` - **required** - string, title of the video
 
-``title`` - **required** - string, title of the video
+* `released` - *optional* - string (ISO 8601), publish date of the video; for episodes, this should be the initial air date
 
-``released`` - **required** - string, ISO 8601, publish date of the video; for episodes, this should be the initial air date, e.g. "2010-12-06T05:00:00.000Z"
+* `overview` - *optional* - string, video overview/summary
 
-``thumbnail`` - _optional_ - string, URL to png of the video thumbnail, in the video's aspect ratio, max file size 5kb
+* `thumbnail` - *optional* - string, URL to image; displayed as the video's thumbnail (recommended max file size of 5kb)
 
-``streams`` - _optional_ - array of [``Stream Objects``](./stream.md), in case you can return links to streams while forming meta response, **you can pass and array of [``Stream Objects``](./stream.md)** to point the video to a HTTP URL, BitTorrent, YouTube or any other stremio-supported transport protocol; note that this is exclusive: passing `video.streams` means that **Stremio will not** request any streams from other addons for that video; if you return streams that way, it is still recommended to implement the `streams` resource
+* `streams` - *optional* - array of [Stream Objects](./stream.md)
+  > **Important**: Passing `video.streams` means that **Stremio will not** request any streams from other addons for that video. If you return streams this way, it is still recommended to implement the `streams` resource.
 
-``available`` - _optional_ - boolean, set to ``true`` to explicitly state that this video is available for streaming, from your addon; no need to use this if you've passed ``streams``
+* `trailerStreams` - *optional* - array of [Stream Objects](./stream.md), contains trailers for the video
 
-``episode`` - _optional_ - number, episode number, if applicable
+* `season` - *optional* - number, season number; if applicable
 
-``season`` - _optional_ - number, season number, if applicable
+* `episode` - *optional* - number, episode number; if applicable
 
-``trailers`` - _optional_ - array, containing [``Stream Objects``](./stream.md)
-
-``overview`` - _optional_ - string, video overview/summary
-
-
-##### Video object - series example
-
-```javascript
-{
-    id: "tt0108778:1:1",
-    title: "Pilot",
-    released: new Date("1994-09-22 20:00 UTC+02"),
-    season: 1,
-    episode: 1,
-    overview: "Monica and the gang introduce Rachel to the real world after she leaves her fiancé at the altar."
-}
-```
-
-You can see a comprehensive example of how detailed Meta objects with videos are returned [here, on the Cinemeta addon](https://v3-cinemeta.strem.io/meta/series/tt0386676/lastVideos=1.json)
-
-##### Video object - YouTube video example (channels)
-
-
-```javascript
-{
-    id: "yt_id:UCrDkAvwZum-UTjHmzDI2iIw:9bZkp7q19f0",
-    title: "PSY - GANGNAM STYLE",
-    released: new Date("2012-07-15 20:00 UTC+02"),
-    thumbnail: "https://i.ytimg.com/vi/9bZkp7q19f0/hqdefault.jpg"
-}
-```
+For Video Object examples, see the `videos` array in the Series and Channel [examples](#examples) below.
 
 ## Meta Preview Object
 
-This is a shorter variant of the previously described [Meta Object](#meta-object)
-
 Used as a response for [`defineCatalogHandler`](../requests/defineCatalogHandler.md)
 
-``id`` - **required** - string, universal identifier; you may use a [prefix](./manifest.md##filtering-properties) unique to your addon, for example `yt_id:UCrDkAvwZum-UTjHmzDI2iIw`
+A meta preview object is identical to a [Meta Object](#meta-object) but **without** the `videos` property. It's used for catalog listings where video details are not needed.
 
-``type`` - **required** - string, type of the content; e.g. `movie`, `series`, `channel`, `tv` (see [Content Types](./content.types.md))
+This object used to contain a lot fewer properties than the Meta Object, but as Stremio has evolved, it is now almost identical.
 
-``name`` - **required** - string, name of the content
+## Examples
 
-``poster`` - **required** - string, URL to png of poster; accepted aspect ratios: 1:0.675 (IMDb poster type) or 1:1 (square); you can use any resolution, as long as the file size is below 100kb; below 50kb is recommended; also used as the background shown on the stremio discover page in the sidebar
+<details>
+<summary>Movie</summary>
 
-``posterShape`` - _optional_ - string, can be `square` (1:1 aspect) or `poster` (1:0.675) or `landscape` (1:1.77). If you don't pass this, `poster` is assumed
+### Movie
 
-#### Additional Parameters that are used for the Discover Page Sidebar:
+```json
+{
+  "id": "tt1254207",
+  "type": "movie",
+  "name": "Big Buck Bunny",
+  "poster": "https://images.metahub.space/poster/small/tt1254207/img",
+  "background": "https://images.metahub.space/background/medium/tt1254207/img",
+  "logo": "https://images.metahub.space/logo/medium/tt1254207/img",
+  "description": "Big' Buck wakes up in his rabbit hole, only to be pestered by three critters, Gimera, Frank and Rinky. When Gimera kills a butterfly, Buck decides on a payback Predator-style",
+  "releaseInfo": "2008",
+  "runtime": "10 min",
+  "released": "2008-04-09T21:00:00.000Z",
+  "links": [
+    {
+      "name": "6.8",
+      "category": "imdb",
+      "url": "https://imdb.com/title/tt1254207"
+    },
+    {
+      "name": "Big Buck Bunny",
+      "category": "share",
+      "url": "https://www.strem.io/s/movie/1254207"
+    },
+    {
+      "name": "Animation",
+      "category": "Genres",
+      "url": "stremio:///discover/https%3A%2F%2Fv3-cinemeta.strem.io%2Fmanifest.json/movie/top?genre=Animation"
+    },
+    {
+      "name": "Sacha Goedegebure",
+      "category": "Directors",
+      "url": "stremio:///search?search=Sacha%20Goedegebure"
+    }
+  ],
+  "trailerStreams": [
+    {
+      "ytId": "YE7VzlLtp-4"
+    }
+  ]
+}
+```
 
-``genres`` - _optional_  - array of strings, genre/categories of the content; e.g. ``["Thriller", "Horror"]`` (warning: this will soon be deprecated in favor of ``links``)
+</details>
 
-``imdbRating`` -  _optional_ - string, IMDb rating, a number from 0.0 to 10.0 ; use if applicable
+<details>
+<summary>Series</summary>
 
-``releaseInfo`` - _optional_ - string, year the content came out ; if it's ``series`` or ``channel``, use a start and end years split by a tide - e.g. ``"2000-2014"``. If it's still running, use a format like ``"2000-"``
+```json
+{
+  "id": "tt0108778",
+  "type": "series",
+  "name": "Friends",
+  "poster": "https://images.metahub.space/poster/small/tt0108778/img",
+  "background": "https://images.metahub.space/background/medium/tt0108778/img",
+  "logo": "https://images.metahub.space/logo/medium/tt0108778/img",
+  "description": "The personal and professional lives of six friends living in the Manhattan borough of New York City.",
+  "releaseInfo": "1994-2004",
+  "runtime": "22 min",
+  "released": "1994-09-22T00:00:00.000Z",
+  "links": [
+    {
+      "name": "8.9",
+      "category": "imdb",
+      "url": "https://imdb.com/title/tt0108778"
+    },
+    {
+      "name": "Friends",
+      "category": "share",
+      "url": "https://www.strem.io/s/series/0108778"
+    }
+    {
+      "name": "Comedy",
+      "category": "Genres",
+      "url": "stremio:///discover/https%3A%2F%2Fv3-cinemeta.strem.io%2Fmanifest.json/series/top?genre=Comedy"
+    },
+    {
+      "name": "Jennifer Aniston",
+      "category": "Cast",
+      "url": "stremio:///search?search=Jennifer%20Aniston"
+    },
+  ],
+  "trailerStreams": [
+    {
+      "title": "Friends",
+      "ytId": "H29XSxoKp80"
+    },
+  ],
+  "videos": [
+    {
+      "id": "tt0108778:1:1",
+      "title": "The One Where Monica Gets a Roommate",
+      "released": "1994-09-22T00:00:00.000Z",
+      "overview": "Monica and the gang introduce Rachel to the \"real world\" after she leaves her fiancé at the altar.",
+      "thumbnail": "https://episodes.metahub.space/tt0108778/1/1/w780.jpg",
+      "season": 1,
+      "episode": 1
+    }
+  ]
+}
+```
 
-``director``, ``cast`` - _optional_  - directors and cast, both arrays of names (string) (warning: this will soon be deprecated in favor of ``links``)
+</details>
 
-``links`` - _optional_ - array of [``Meta Link objects``](#meta-link-object), can be used to link to internal pages of Stremio, example usage: array of actor / genre / director links
+<details>
+<summary>Channel</summary>
 
-``description`` - _optional_ - string, a few sentances describing your content
+```json
+{
+  "id": "yt_id:UCrDkAvwZum-UTjHmzDI2iIw",
+  "type": "channel",
+  "name": "officialpsy",
+  "poster": "https://yt3.ggpht.com/kJ8zwS_VhJ0TE-XDumnshGQ86hazfhHjjU4xn80Dc8xmSghA_2xw4OJTHaGreyeoro6q_vcT",
+  "posterShape": "square",
+  "description": "PSY Official YouTube Channel",
+  "videos": [
+    {
+      "id": "yt_id:UCrDkAvwZum-UTjHmzDI2iIw:9bZkp7q19f0",
+      "title": "PSY - GANGNAM STYLE(강남스타일) M/V",
+      "released": "2012-07-15T07:46:32.000Z",
+      "thumbnail": "https://i.ytimg.com/vi/9bZkp7q19f0/default.jpg"
+    }
+  ]
+}
+```
 
-``trailers`` - _optional_ - array, containing objects in the form of `{ "source": "P6AaSMfXHbA", "type": "Trailer" }`, where `source` is a YouTube Video ID and `type` can be either `Trailer` or `Clip` (warning: this will soon be deprecated in favor of `meta.trailers` being an array of [``Stream Objects``](./stream.md))
+</details>
+
+<details>
+<summary>TV</summary>
+
+```json
+{
+  "id": "tv:pbs",
+  "type": "tv",
+  "name": "PBS",
+  "poster": "https://prod-gacraft.console.pbs.org/favicon.png",
+  "posterShape": "square",
+  "streams": [
+    {
+      "description": "Official PBS stream",
+      "behaviorHints": {
+        "notWebReady": true
+      },
+      "url": "https://pbs.lls.cdn.pbs.org/est/index.m3u8",
+    },
+  ]
+}
+```
+
+</details>

--- a/docs/api/responses/stream.md
+++ b/docs/api/responses/stream.md
@@ -72,6 +72,10 @@ A stream object consists of [common properties](#common-properties) and **exactl
 * `tarUrls` - **required** - array of [Source Objects](#source-objects) pointing to TAR files
   > **Limitations**: does not support multi-volume and decompression by design (TAE only merges multiple files into one without compressing), seeking is supported
 
+#### External Stream
+
+* `externalUrl` - **required** - string, a link to a stream outside of Stremio; will open externally instead of being played by Stremio (e.g. a Netflix link)
+
 ### Source Objects
 
 An object representing a streaming source for archive files. Each source object has the following structure:

--- a/docs/api/responses/stream.md
+++ b/docs/api/responses/stream.md
@@ -2,57 +2,79 @@
 
 Used as a response for [`defineStreamHandler`](../requests/defineStreamHandler.md)
 
-**One of the following must be passed** to point to the stream itself
+A stream object consists of [common properties](#common-properties) and **exactly one** [source type configuration](#source-types).
 
-* ``url`` - string, direct http(s)/ftp(s)/rtmp link to a video stream (protocol support can vary depending on client app capabilities)
-* ``ytId`` - string, youtube video ID, plays using the built-in YouTube player
-* ``infoHash`` - string, info hash of a torrent file, and `fileIdx` is the index of the video file within the torrent; **if fileIdx is not specified, the largest file in the torrent will be selected**
-* ``fileIdx`` - number, the index of the video file within the torrent (from `infoHash`), nzb (from `nzbUrl`), rar (from `rarUrls`, zip (from `zipUrls`), 7zip (from `7zipUrls`), tgz (from `tgzUrls`), tar (from `tarUrls`)); (for torrents if fileIdx is not specified, the largest file will be selected)
-* ``fileMustInclude`` - string, a string representing a regex (example `"/.mkv$|.mp4$|.avi$|.ts$/i"`) to match the video file within the nzb (from `nzbUrl`), rar (from `rarUrls`, zip (from `zipUrls`), 7zip (from `7zipUrls`), tgz (from `tgzUrls`), tar (from `tarUrls`)); (not supported for torrents yet)
-* ``nzbUrl`` - string, http(s) or ftp(s) link to a NZB (usenet) file (this source will also unpack any known archive files), also see: [``Source Limitations``](#source-limitations)
-* ``servers`` - array, a list of strings that each represent a connection to a NNTP (usenet) server (for `nzbUrl`) in the form of `nntp(s)://{user}:{pass}@{nntpDomain}:{nntpPort}/{nntpConnections}` (`nntps` = SSL; `nntp` = no encryption) (example: `nntps://myuser:mypass@news.example.com:563/4`)
-* ``rarUrls`` - array, a list of [``Source Objects``](#source-objects) that lead to rar files (multi-volume supported), also see: [``Source Limitations``](#source-limitations)
-* ``zipUrls`` - array, a list of [``Source Objects``](#source-objects) that lead to zip files (multi-volume supported), also see: [``Source Limitations``](#source-limitations)
-* ``7zipUrls`` - array, a list of [``Source Objects``](#source-objects) that lead to 7z files (multi-volume supported), also see: [``Source Limitations``](#source-limitations)
-* ``tgzUrls`` - array, a list of [``Source Objects``](#source-objects) that lead to tgz files (multi-volume supported), also see: [``Source Limitations``](#source-limitations)
-* ``tarUrls`` - array, a list of [``Source Objects``](#source-objects) that lead to tar files (TAR does not support multi-volume), also see: [``Source Limitations``](#source-limitations)
-* ``externalUrl`` - string, [``Meta Link``](./meta.links.md) or an external URL to the video, which should be opened in a browser (webpage), e.g. link to Netflix
+### Common Properties
 
-### Additional properties to provide information / behaviour flags
+* `name` - *optional* - string, name of the stream; usually used for stream quality
 
-- ``name`` - _optional_ - string, name of the stream; usually used for stream quality
+* `description` - *optional* - string, description of the stream
 
-- ``title`` - _optional_ - string, description of the stream (warning: this will soon be deprecated in favor of `stream.description`)
+* `thumbnail` - *optional* - string, URL to a thumbnail image for the stream
 
-- ``description`` - _optional_ - string, description of the stream (previously `stream.title`)
+* `subtitles` - *optional* - array of [Subtitle objects](./subtitles.md) representing subtitles for this stream
 
-- ``subtitles`` - _optional_ - array of [``Subtitle objects``](./subtitles.md) representing subtitles for this stream
+* `behaviorHints` - *optional* - object with behavior configuration, contains the following properties:
 
-- ``sources`` - _optional_ - array of strings, represents a list of torrent tracker URLs and DHT network nodes. This attribute can be used to provide additional peer discovery options when `infoHash` is also specified, but it is not required. If used, each element can be a tracker URL (`tracker:<protocol>://<host>:<port>`) where `<protocol>` can be either `http` or `udp`. A DHT node (`dht:<node_id/info_hash>`) can also be included.
+  * `countryWhitelist` - *optional* - array of ISO 3166-1 alpha-3 country codes **in lowercase** in which the stream is accessible
+
+  * `notWebReady` - *optional* - boolean, applies if the protocol of the URL is http(s); needs to be set to `true` if the URL does not support HTTPS or is not an MP4 file
+
+  * `bingeGroup` - *optional* - string, if defined, streams with the same `bingeGroup` will be chosen automatically for binge watching; this should identify the stream's nature within your addon (example: if your addon is "gobsAddon" and the stream is 720p, use "gobsAddon-720p"); if the next episode has a stream with the same `bingeGroup`, Stremio will select that stream implicitly
+
+  * `proxyHeaders` - *optional* - object, only applies to `url` sources; **When using this property, you must also set `stream.behaviorHints.notWebReady: true`**; contains `request` and `response` properties with headers that should be used for the stream (example: `{ "request": { "User-Agent": "Stremio" } }`)
+
+  * `videoHash` - *optional* - string, the calculated [OpenSubtitles hash](http://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes) of the video; used when the streaming server is not connected (so the hash cannot be calculated locally). This value is passed to subtitle addons to identify correct subtitles
+
+  * `videoSize` - *optional* - number, size of the video file in bytes; this value is passed to subtitle addons to identify correct subtitles
+
+  * `filename` - *optional* - string, filename of the video file; although optional, it is highly recommended to set it when using `url` sources (when possible) in order to identify correct subtitles (addon SDK will show a warning if not set in this case). This value is passed to subtitle addons to identify correct subtitles
+
+### Source Types
+
+#### Direct URL Stream
+
+* `url` - string, direct http(s)/ftp(s)/rtmp link to a video stream (protocol support can vary depending on client app capabilities)
+
+#### YouTube Stream
+
+* `ytId` - string, YouTube video ID, plays using the built-in YouTube player
+
+#### Torrent Stream
+
+* `infoHash` - **required** - string, info hash of a torrent file
+* `fileIdx` - *optional* - number, index of the video file within the torrent; **if not specified, the largest file will be selected**
+* `announce` - *optional* - array of strings, torrent tracker URLs and DHT network nodes in the form `tracker:<protocol>://<host>:<port>` where `<protocol>` can be `http` or `udp`, or DHT nodes as `dht:<node_id/info_hash>`
   > **WARNING**: Use of DHT may be prohibited by some private trackers as it exposes torrent activity to a broader network, potentially finding more peers.
+* `fileMustInclude` - *optional* - array of strings, each representing a regex pattern to match the video file (e.g. `["/.mkv$|.mp4$|.avi$/i"]`)
 
-- `behaviorHints` (all are optional)
-    - `countryWhitelist`: which hints it's restricted to particular countries  - array of ISO 3166-1 alpha-3 country codes **in lowercase** in which the stream is accessible
-    - `notWebReady`: applies if the protocol of the url is http(s); needs to be set to `true` if the URL does not support https or is not an MP4 file
-    - `bingeGroup`: if defined, addons with the same `behaviorHints.bingeGroup` will be chosen automatically for binge watching; this should be something that identifies the stream's nature within your addon: for example, if your addon is called "gobsAddon", and the stream is 720p, the bingeGroup should be "gobsAddon-720p"; if the next episode has a stream with the same `bingeGroup`, stremio should select that stream implicitly
-    - `proxyHeaders`: only applies to `url`s; **When using this property, you must also set `stream.behaviorHints.notWebReady: true`**; This is an object containing `request` and `response` which include the headers that should be used for the stream (example value: `{ "request": { "User-Agent": "Stremio" } }`)
-    - `videoHash`: - string, the calculated [OpenSubtitles hash](http://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes) of the video, this will be used when the streaming server is not connected (so the hash cannot be calculated locally), this value is passed to subtitle addons to identify correct subtitles
-    - `videoSize`: - number, size of the video file in bytes, this value is passed to the subtitle addons to identify correct subtitles
-    - `filename`: - string, filename of the video file, although optional, it is highly recommended to set it when using `stream.url` (when possible) in order to identify correct subtitles (addon sdk will show a warning if it is not set in this case), this value is passed to the subtitle addons to identify correct subtitles
+#### NZB Stream (Usenet)
+
+* `nzbUrl` - **required** - string, http(s) or ftp(s) link to a NZB file (this source will also unpack any known archive files)
+  > **Limitations**: will also unpack all known archive types, NZB files cannot be streamed unless both the first and last segment of the video file are retrievable, PAR2 recovery is not supported
+* `servers` - **required** - array of strings, NNTP (usenet) server connections in the form `nntp(s)://{user}:{pass}@{nntpDomain}:{nntpPort}/{nntpConnections}` where `nntps` = SSL, `nntp` = no encryption (e.g. `nntps://myuser:mypass@news.example.com:563/4`)
+
+#### Archive Streams
+
+* `fileIdx` - *optional* - number, index of the video file within the archive
+* `fileMustInclude` - *optional* - array of strings, each representing a regex pattern to match the video file (e.g. `["/.mkv$|.mp4$|.avi$/i"]`)
+
+**Exactly one** of the following properties is also required, depending on the archive format:
+
+* `rarUrls` - **required** - array of [Source Objects](#source-objects) pointing to RAR files
+  > **Limitations**: multi-volume and seeking in the video supported, decompression is not supported (decompression is not normally required for audio / video files)
+* `zipUrls` - **required** - array of [Source Objects](#source-objects) pointing to ZIP files (multi-volume supported)
+  > **Limitations**: multi-volume and decompression are supported, it does not support seeking in the video
+* `7zipUrls` - **required** - array of [Source Objects](#source-objects) pointing to 7z files
+  > **Limitations**: multi-volume and LZMA decompression are supported, it supports seeking only when compression is not used (decompression is not normally required for audio / video files)
+* `tgzUrls` - **required** - array of [Source Objects](#source-objects) pointing to TGZ files
+  > **Limitations**: multi-volume and decompression are supported, it does not support seeking in the video
+* `tarUrls` - **required** - array of [Source Objects](#source-objects) pointing to TAR files
+  > **Limitations**: does not support multi-volume and decompression by design (TAE only merges multiple files into one without compressing), seeking is supported
 
 ### Source Objects
 
-An object representing a streaming source, supports the following properties:
+An object representing a streaming source for archive files. Each source object has the following structure:
 
-* ``url`` - **required** - string, direct http(s)/ftp(s) link to a file (depending on context: zip, rar, 7z, tar, tgz)
-* ``bytes`` - _optional_ - integer, size of the file in bytes - while optional adding this can speed up the initial buffering
-
-### Source Limitations
-
-- nzb: will also unpack all known archive types, a nzb files cannot be streamed unless both the first and last segment of the video file are retrievable, PAR2 recovery is not supported
-- rar: multi-volume and seeking in the video supported, decompression is not supported (decompression is not normally required for audio / video files)
-- zip: multi-volume and decompression are supported, it does not support seeking in the video
-- 7zip: multi-volume and LZMA decompression are support, it supports seeking only when compression is not used (decompression is not normally required for audio / video files)
-- tar: does not support multi-volume and decompression by design (tar only merges multiple files into one without compressing), seeking is supported
-- tgz: multi-volume and decompression are supported, it does not support seeking in the video
-
+* `url` - **required** - string, direct http(s)/ftp(s) link to an archive file (rar, zip, 7z, tgz, tar)
+* `bytes` - *optional* - number, size of the file in bytes; while optional, adding this can speed up the initial buffering


### PR DESCRIPTION
I noticed that a lot of the information in the docs did not reflect stremio-core, so have rewritten it to match what's actually in the code, and hopefully provide better clarity with the stream types.

Decided not to touch the manifest docs as it's too important.

Claude was used for formatting and generating examples, but have manually verified all content.